### PR TITLE
Accessibility (a11y) improvement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Changes (unreleased)
 
+- Remove not-so-useful Unicode characters from output
 - Add missing linebreaks in the project list of activity report (#148, @gpetiot)
 - Use ocamlformat 0.21.0
 - CSV parsing updates. Include new fields for reports and links. (@magnuss)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Changes (unreleased)
 
-- Remove not-so-useful Unicode characters from output
+- Remove not-so-useful Unicode characters from output for a11y accessibility (#151, @shindere)
 - Add missing linebreaks in the project list of activity report (#148, @gpetiot)
 - Use ocamlformat 0.21.0
 - CSV parsing updates. Include new fields for reports and links. (@magnuss)

--- a/src/team.ml
+++ b/src/team.ml
@@ -65,10 +65,10 @@ let lint admin_dir ~year ~weeks teams =
   List.map (fun team -> (team, lint_team (members team))) teams
 
 let pp_report ppf = function
-  | Not_found fpath -> Fmt.pf ppf "Not found: %s ❌" fpath
-  | Complete _ -> Fmt.pf ppf "Complete ✅"
+  | Not_found fpath -> Fmt.pf ppf "Not found: %s" fpath
+  | Complete _ -> Fmt.pf ppf "Complete"
   | Erroneous (fpath, e) ->
-      Fmt.pf ppf "Lint error at %s ⚠️@ @[<v 0>%a@]" fpath Lint.pp_error e
+      Fmt.pf ppf "Lint error at %s @[<v 0>%a@]" fpath Lint.pp_error e
 
 let pp_lint_report ppf lint_report =
   let pp_report_lint ppf (week, report) =

--- a/src/team.ml
+++ b/src/team.ml
@@ -68,7 +68,7 @@ let pp_report ppf = function
   | Not_found fpath -> Fmt.pf ppf "Not found: %s" fpath
   | Complete _ -> Fmt.pf ppf "Complete"
   | Erroneous (fpath, e) ->
-      Fmt.pf ppf "Lint error at %s @[<v 0>%a@]" fpath Lint.pp_error e
+      Fmt.pf ppf "Lint error at %s@ @[<v 0>%a@]" fpath Lint.pp_error e
 
 let pp_lint_report ppf lint_report =
   let pp_report_lint ppf (week, report) =

--- a/test/cram/team-lint.t/run.t
+++ b/test/cram/team-lint.t/run.t
@@ -4,13 +4,13 @@ Team Lint example
   $ okra team lint -C admin/ -W 40-42 -y 2022 --conf ./conf.yml
   === My Team ===
     + Engineer 1
-      + Report week 40: Complete ✅
-      + Report week 41: Complete ✅
-      + Report week 42: Not found: admin//weekly/2022/42/eng1.md ❌
+      + Report week 40: Complete
+      + Report week 41: Complete
+      + Report week 42: Not found: admin//weekly/2022/42/eng1.md
     + Engineer 2
-      + Report week 40: Not found: admin//weekly/2022/40/eng2.md ❌
-      + Report week 41: Lint error at admin//weekly/2022/41/eng2.md ⚠️
+      + Report week 40: Not found: admin//weekly/2022/40/eng2.md
+      + Report week 41: Lint error at admin//weekly/2022/41/eng2.md
                         Line 4: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                         Line 5: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                         2 formatting errors found. Parsing aborted.
-      + Report week 42: Not found: admin//weekly/2022/42/eng2.md ❌
+      + Report week 42: Not found: admin//weekly/2022/42/eng2.md


### PR DESCRIPTION
This PR removes some fancy Unicode characters used to report whether
reports were found or not, with errors or not.

This characters cannot easily be displayed in braille so they are rather
annoying (all displayed as question marks), for a benefit for sighted people
which is perhaps not that big after all...