### PR TITLE
Add a version number to weeklies for retro-compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Changes (unreleased)
 
+- Add a version number to weeklies for retro-compatibility (#<PR_NUMBER>, @gpetiot)
 - Fail with an explicit error message when --repo-dir is missing (#152, @gpetiot)
 - Remove not-so-useful Unicode characters from output for a11y accessibility (#151, @shindere)
 - Add missing linebreaks in the project list of activity report (#148, @gpetiot)

--- a/bin/dune
+++ b/bin/dune
@@ -11,7 +11,6 @@
   fmt.cli
   logs.cli
   fmt.tty
-  dune-build-info
   xdg)
  (preprocess
   (pps ppx_deriving_yaml)))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -21,11 +21,7 @@ open Cmdliner
 let root_term = Term.ret (Term.const (`Help (`Pager, None)))
 
 let root_info =
-  let version =
-    match Build_info.V1.version () with
-    | None -> "dev"
-    | Some v -> Build_info.V1.Version.to_string v
-  in
+  let version = Okra.Version.(Lib.to_string @@ current) in
   Cmd.info "okra" ~version ~doc:"a tool to parse and process OKR reports"
     ~man:
       [

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,14 @@
 (library
  (name okra)
  (public_name okra)
- (libraries lwt logs omd fmt str calendar csv get-activity gitlab))
+ (libraries
+  dune-build-info
+  lwt
+  logs
+  omd
+  fmt
+  str
+  calendar
+  csv
+  get-activity
+  gitlab))

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -17,6 +17,9 @@
 
 type lint_error =
   | Format_error of (int * string) list
+  | No_version_found
+  | Invalid_version of int option * string
+  | Unsupported_version of int option * string
   | No_time_found of int option * string
   | Invalid_time of int option * string
   | Multiple_time_entries of int option * string

--- a/src/parser.mli
+++ b/src/parser.mli
@@ -16,6 +16,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+exception No_version_found
+exception Invalid_version of string
+exception Unsupported_version of string
 exception No_time_found of string
 exception Multiple_time_entries of string
 exception Invalid_time of string
@@ -24,14 +27,17 @@ exception No_KR_ID_found of string
 exception No_project_found of string
 exception Not_all_includes_accounted_for of string list
 
-type markdown = (string * string) list Omd.block list
+type markdown = Omd.doc
 (** The type for markdown files. *)
+
+type metadata = { version : Version.Lang.t }
+type weekly = { meta : metadata; doc : KR.t list }
 
 val of_markdown :
   ?ignore_sections:string list ->
   ?include_sections:string list ->
   markdown ->
-  KR.t list
+  weekly
 (** Process markdown data from omd. Optionally [ignore_sections] can be used to
     ignore specific sections, or [include_sections] can be used to only process
     specific sections. *)

--- a/src/report.ml
+++ b/src/report.ml
@@ -238,7 +238,8 @@ let of_objectives ~project objectives =
   of_projects [ p ]
 
 let of_markdown ?existing_report ?ignore_sections ?include_sections ?okr_db m =
-  let new_krs = Parser.of_markdown ?ignore_sections ?include_sections m in
+  let weekly = Parser.of_markdown ?ignore_sections ?include_sections m in
+  let new_krs = weekly.doc in
   let old_krs = match existing_report with None -> [] | Some t -> all_krs t in
   let krs = old_krs @ new_krs in
   of_krs ?okr_db krs

--- a/src/version.ml
+++ b/src/version.ml
@@ -1,0 +1,65 @@
+let int_of_string_result s =
+  match int_of_string s with i -> Ok i | exception Failure e -> Error (`Msg e)
+
+module Result = struct
+  include Result
+
+  module Let_syntax = struct
+    let ( let+ ) x f = Result.map f x
+    let ( let* ) = Result.bind
+  end
+end
+
+module Lang = struct
+  type t = { major : int; minor : int }
+
+  let pp fs v = Format.fprintf fs "%i.%i" v.major v.minor
+  let to_string v = Format.asprintf "%a" pp v
+
+  let of_string s =
+    let open Result.Let_syntax in
+    match String.split_on_char '.' s with
+    | [ a; b ] ->
+        let* major = int_of_string_result a in
+        let+ minor = int_of_string_result b in
+        { major; minor }
+    | _ -> Error (`Msg "Lang.of_string: invalid string format")
+end
+
+module Lib = struct
+  type t = Release of { major : int; minor : int; patch : int } | Dev
+
+  let pp fs = function
+    | Release v -> Format.fprintf fs "%i.%i.%i" v.major v.minor v.patch
+    | Dev -> Format.fprintf fs "dev"
+
+  let to_string v = Format.asprintf "%a" pp v
+
+  let of_string s =
+    let open Result.Let_syntax in
+    match s with
+    | "dev" -> Ok Dev
+    | _ -> (
+        match String.split_on_char '.' s with
+        | [ a; b; c ] ->
+            let* major = int_of_string_result a in
+            let* minor = int_of_string_result b in
+            let+ patch = int_of_string_result c in
+            Release { major; minor; patch }
+        | _ -> Error (`Msg "Lib.of_string: invalid string format"))
+
+  let can_read ~lang = function
+    | Release { major; minor; patch = _ } ->
+        Int.compare major lang.Lang.major > 0
+        || Int.compare major lang.major = 0
+           && Int.compare minor lang.minor >= 0
+    | Dev -> true (* more advanced than any release *)
+end
+
+let current =
+  let open Build_info.V1 in
+  match version () with
+  | Some v -> (
+      let s = Version.to_string v in
+      match Lib.of_string s with Ok v -> v | Error _ -> Dev)
+  | None -> Dev

--- a/src/version.mli
+++ b/src/version.mli
@@ -1,0 +1,18 @@
+module Lang : sig
+  type t = { major : int; minor : int }
+
+  val pp : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_string : string -> (t, [ `Msg of string ]) result
+end
+
+module Lib : sig
+  type t = Release of { major : int; minor : int; patch : int } | Dev
+
+  val pp : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_string : string -> (t, [ `Msg of string ]) result
+  val can_read : lang:Lang.t -> t -> bool
+end
+
+val current : Lib.t

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -1,6 +1,23 @@
 Types of errors
 ---------------
 
+Invalid version:
+
+  $ okra lint << EOF
+  > version
+  > : ~-100.0
+  > 
+  > # Title
+  > 
+  > - This is a KR
+  >   - @eng1 (1 day)
+  >   - My work
+  > EOF
+  [ERROR(S)]: <stdin>
+  
+  Invalid version: "~-100.0"
+  [1]
+
 No KR ID found:
 
   $ okra lint << EOF


### PR DESCRIPTION
The version of the tool doesn't change, we still rely on `dune-build-info`, and when not set, it is still `dev`.

We now accept (not require yet) a version at the beginning of the weekly:
```
version
: 0.1
```
that's the syntax for definition list (the `:` should start the line).

- For this first version, if it is omitted it is set to `0.1` during the parsing to not break the tests and the existing files.
- If the version number is invalid, an error is raised.
- the `dev` version is considered to be the most recent so can read every version.
- in the future (0.2), a missing version at the beginning of a weekly report will raise an error.

