### PR TITLE
Use github URL in README for adding tarides/opam-repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Install opam if you don't already have it, and add [`tarides/opam-repository`](h
 Either only to the current opam switch with the command
 
 ```
-opam repository add tarides git@github.com:tarides/opam-repository.git
+opam repository add tarides https://github.com/tarides/opam-repository.git
 ```
 
 Or to the list of opam repositories for all opam switches with the command:
 ```
-opam repository add --all tarides git@github.com:tarides/opam-repository.git
+opam repository add --all tarides https://github.com/tarides/opam-repository.git
 ```
 
 Update your list of packages:


### PR DESCRIPTION
When trying to add tarides/opam-repository following the README, I get this:

```
$ opam repository add tarides git@github.com:tarides/opam-repository.git
[ERROR] Could not update repository "tarides": "/usr/bin/git fetch -q" exited with code 128
[ERROR] Initial repository fetch failed
```

However,

```
opam repository add tarides https://github.com/tarides/opam-repository.git
```

works fine.