### PR TITLE
Make github handles clickable in repo reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Changes
 
-- Make github handles clickable in repo reports (#<PR_NUMBER>, @gpetiot)
+- Make github handles clickable in repo reports (#193, @gpetiot)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Changes
+
+- Make github handles clickable in repo reports (#<PR_NUMBER>, @gpetiot)
+
 ### Fixed
 
 - Using an empty conf should not fail, better message in case of error (#192, @gpetiot)

--- a/lib/repo_report.ml
+++ b/lib/repo_report.ml
@@ -147,9 +147,12 @@ module PR = struct
 
   let pp ~with_names ~with_times ~with_descriptions ppf
       { author; title; url; created_at; merged_at; reviewers; body; _ } =
-    let pp_user ppf = Fmt.pf ppf "@%s" in
+    let pp_user ppf u = Fmt.pf ppf "[@%s](https://github.com/%s)" u u in
     let pp_created_at ppf = Fmt.pf ppf " (created/merged: %s)" in
     let pp_author ppf = Fmt.pf ppf " by %a" pp_user in
+    let reviewers =
+      List.filter (fun x -> not (String.equal "github-actions" x)) reviewers
+    in
     if reviewers = [] || not with_names then
       Fmt.(
         pf ppf " - [%s](%s)%a%a\n   %a\n" title url (option pp_author)

--- a/test/expect/test_monthly.expected
+++ b/test/expect/test_monthly.expected
@@ -5,17 +5,17 @@ Irmin is a distributed database that follows the same design principles as Git
 
 #### Opened (and not merged in same time frame)
 
- - [Small fix](https://github.com/mirage/irmin) by @Bactrian
+ - [Small fix](https://github.com/mirage/irmin) by [@Bactrian](https://github.com/Bactrian)
 
-   (created: 2021-02-01T00:00:00Z, reviewed by: @Dromedary)
+   (created: 2021-02-01T00:00:00Z, reviewed by: [@Dromedary](https://github.com/Dromedary))
    Fixes a small thing
 
 
 #### Merged
 
- - [Smaller fix](https://github.com/mirage/irmin) by @Bactrian
+ - [Smaller fix](https://github.com/mirage/irmin) by [@Bactrian](https://github.com/Bactrian)
 
-   (merged: 2021-02-01T00:00:02Z, reviewed by: @Dromedary)
+   (merged: 2021-02-01T00:00:02Z, reviewed by: [@Dromedary](https://github.com/Dromedary))
    Fixes a really small thing
 
 


### PR DESCRIPTION
Suggested by @sabine 