### PR TITLE
Parser collects all issues instead of raising an exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 ### Changes
 
 - Make github handles clickable in repo reports (#193, @gpetiot)
-- Parser collects all issues instead of raising an exception (#195, @gpetiot)
+- Parser collects all issues instead of raising an exception (#195, @gpetiot).
+  Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Changes
 
 - Make github handles clickable in repo reports (#193, @gpetiot)
+- Parser collects all issues instead of raising an exception (#195, @gpetiot)
 
 ### Fixed
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -24,8 +24,9 @@ type lint_error =
   | No_KR_ID_found of int option * string
   | No_project_found of int option * string
   | Not_all_includes of string list
+  | Invalid_markdown_in_work_items of int option * string
 
-type lint_result = (unit, lint_error) result
+type lint_result = (unit, lint_error list) result
 
 val lint :
   ?okr_db:Masterdb.t ->

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -16,22 +16,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-exception No_time_found of string
-exception Multiple_time_entries of string
-exception Invalid_time of string
-exception No_work_found of string
-exception No_KR_ID_found of string
-exception No_project_found of string
-exception Not_all_includes_accounted_for of string list
+type warning =
+  | No_time_found of string  (** Record found without a time record *)
+  | Multiple_time_entries of string  (** More than one time entry found *)
+  | Invalid_time of string  (** Time record found, but has errors *)
+  | No_work_found of string  (** No work items found under KR *)
+  | No_KR_ID_found of string  (** Empty or no KR ID *)
+  | No_project_found of string  (** No project found *)
+  | Not_all_includes_accounted_for of string list
+      (** There should be a section for all include sections passed to the parser *)
+  | Invalid_markdown_in_work_items of string
+      (** Subset of markdown not supported in work items *)
 
-type markdown = (string * string) list Omd.block list
+type markdown = Omd.doc
 (** The type for markdown files. *)
 
 val of_markdown :
   ?ignore_sections:string list ->
   ?include_sections:string list ->
   markdown ->
-  KR.t list
+  KR.t list * warning list
 (** Process markdown data from omd. Optionally [ignore_sections] can be used to
     ignore specific sections, or [include_sections] can be used to only process
     specific sections. *)

--- a/lib/team.ml
+++ b/lib/team.ml
@@ -31,7 +31,7 @@ let members { members; _ } = members
 type report =
   | Not_found of string
   | Complete of string
-  | Erroneous of (string * Lint.lint_error)
+  | Erroneous of (string * Lint.lint_error list)
 
 type lint_report = (t * (Member.t * (int * report) list) list) list
 
@@ -68,7 +68,8 @@ let pp_report ppf = function
   | Not_found fpath -> Fmt.pf ppf "Not found: %s" fpath
   | Complete _ -> Fmt.pf ppf "Complete"
   | Erroneous (fpath, e) ->
-      Fmt.pf ppf "Lint error at %s@ @[<v 0>%a@]" fpath Lint.pp_error e
+      Fmt.pf ppf "Lint error at %s@ @[<v 0>%a@]" fpath (Fmt.list Lint.pp_error)
+        e
 
 let pp_lint_report ppf lint_report =
   let pp_report_lint ppf (week, report) =

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -64,6 +64,10 @@ Errors in include section are detected even if the rest is ignored.
   
   In KR "This is a KR (KRID)":
     No time entry found. Each KR must be followed by '- @... (x days)'
+  [ERROR(S)]: <stdin>
+  
+  In KR "This is a KR (KRID)":
+    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
   [1]
 
 Only "No KR" and "New KR" are supported for KR's without identifiers

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -38,6 +38,10 @@ No work items found:
   
   In KR "This is a KR (KRID)":
     No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
+  [ERROR(S)]: <stdin>
+  
+  In KR "This is a KR (KRID)":
+    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
   [1]
 
 No time entry found:

--- a/test/cram/lint/features.t
+++ b/test/cram/lint/features.t
@@ -47,13 +47,13 @@ When errors are found in several files, they are all printed:
   >   - Do it
   > EOF
   $ okra lint err.md err2.md
-  [ERROR(S)]: err.md
-  
-  In KR "Everything is great":
-    No time entry found. Each KR must be followed by '- @... (x days)'
   [ERROR(S)]: err2.md
   
   In KR "@a":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
+  [ERROR(S)]: err.md
+  
+  In KR "Everything is great":
+    No time entry found. Each KR must be followed by '- @... (x days)'
   [1]

--- a/test/cram/lint/short.t
+++ b/test/cram/lint/short.t
@@ -35,7 +35,8 @@ This also works with files:
   > EOF
 
   $ okra lint --short a.md b.md
+  b.md:1:No time found in "Everything is great"
+  b.md:1:No project found for "Everything is great"
   a.md:4:* used as bullet point, this can confuse the parser. Only use - as bullet marker.
   a.md:5:* used as bullet point, this can confuse the parser. Only use - as bullet marker.
-  b.md:1:No time found in "Everything is great"
   [1]


### PR DESCRIPTION
The goal is to not have other commands fail when the file could be exploited.
It allows to print everything that's wrong with the file at once.

The locations are not kept in the markdown and would be tricky to get, they can be added later.

There are a few regressions to fix (not commited).