### PR TITLE
Use ocaml-re instead of str for regexp matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 
 - Using an empty conf should not fail, better message in case of error (#192, @gpetiot)
 
+### Added
+
+- Add `ocaml-re` dependency instead of using `str` (#198, @gpetiot)
+
 ## 0.4.0
 
 ### Changed

--- a/dune-project
+++ b/dune-project
@@ -43,4 +43,5 @@
   (gitlab (>= 0.1.7))
   (calendar (>= 3.0.0))
   (csv (>= 2.4))
+  re
   (omd (>= 2.0.0~alpha3))))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra-lib)
- (libraries logs omd fmt str calendar csv get-activity-lib gitlab))
+ (libraries logs omd fmt re calendar csv get-activity-lib gitlab))

--- a/okra-lib.opam
+++ b/okra-lib.opam
@@ -18,6 +18,7 @@ depends: [
   "gitlab" {>= "0.1.7"}
   "calendar" {>= "3.0.0"}
   "csv" {>= "2.4"}
+  "re"
   "omd" {>= "2.0.0~alpha3"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Follow-up on #177 (cc @punchagan @ganeshn-gh)

The goal is to merge the 2 checks that were done: the first added in #177 checking the general shape and the .5 granularity, the second extracting the data from the groups.

And also using `re` makes it easier to maintain to my opinion.

If becomes easy to also allow submissions in hours and to check a different format.

@punchagan @ganeshn-gh do you want to have a look before I merge?