### PR TITLE
okra gen report: PR/issue entries formatted the same way as in engineer reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
 - Improve the "Invalid time" error messages (#199, @gpetiot)
 - okra team lint: only print details of invalid/missing files, or total of valid files (#200, @gpetiot)
-- okra gen report: PR/issue entries formatted the same way as in engineer reports (#<PR_NUMBER>, @gpetiot)
+- okra gen report: PR/issue entries formatted the same way as in engineer reports (#201, @gpetiot)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
 - Improve the "Invalid time" error messages (#199, @gpetiot)
 - okra team lint: only print details of invalid/missing files, or total of valid files (#200, @gpetiot)
+- okra gen report: PR/issue entries formatted the same way as in engineer reports (#<PR_NUMBER>, @gpetiot)
 
 ### Fixed
 

--- a/lib/activity.mli
+++ b/lib/activity.mli
@@ -23,6 +23,10 @@ type project = { title : string; items : string list }
 val make : projects:project list -> Get_activity.Contributions.t -> t
 (** [make_activity ~projects activites] builds a new weekly activity *)
 
+val repo_org :
+  ?with_id:bool -> ?no_links:bool -> Format.formatter -> string -> unit
+(** [report_org fs url] pretty-prints [url] in the form [repo/id]. *)
+
 val pp_ga_item :
   ?gitlab:bool -> no_links:bool -> unit -> Get_activity.Contributions.item Fmt.t
 (** [pp_ga_item ?gitlab ~no_links () ppf item] prints the get-activity item. See

--- a/lib/repo_report.ml
+++ b/lib/repo_report.ml
@@ -62,7 +62,9 @@ module Issue = struct
     let pp_created_at ppf = Fmt.pf ppf " (created/merged: %s)" in
     let pp_author ppf = Fmt.pf ppf " by %a" pp_user in
     Fmt.(
-      pf ppf " - [%s](%s)%a%a\n   %a\n" title url (option pp_author)
+      pf ppf " - Issue: %s %a %a%a\n   %a\n" title
+        (Activity.repo_org ~with_id:true ~no_links:false)
+        url (option pp_author)
         (if not with_names then None else author)
         (option pp_created_at)
         (if not with_times then None else Some created_at)
@@ -155,7 +157,9 @@ module PR = struct
     in
     if reviewers = [] || not with_names then
       Fmt.(
-        pf ppf " - [%s](%s)%a%a\n   %a\n" title url (option pp_author)
+        pf ppf " - PR: %s %a %a%a\n   %a\n" title
+          (Activity.repo_org ~with_id:true ~no_links:false)
+          url (option pp_author)
           (if not with_names then None else author)
           (option pp_created_at)
           (if not with_times then None
@@ -165,7 +169,8 @@ module PR = struct
           (if not with_descriptions then None else Some body))
     else
       Fmt.(
-        pf ppf " - [%s](%s) by %a\n\n   (%s, reviewed by: %a)\n   %a\n" title
+        pf ppf " - PR: %s %a by %a\n\n   (%s, reviewed by: %a)\n   %a\n" title
+          (Activity.repo_org ~with_id:true ~no_links:false)
           url pp_user
           (Option.value ~default:"No author" author)
           (Option.value ~default:("created: " ^ created_at)

--- a/test/expect/test_monthly.expected
+++ b/test/expect/test_monthly.expected
@@ -5,7 +5,7 @@ Irmin is a distributed database that follows the same design principles as Git
 
 #### Opened (and not merged in same time frame)
 
- - [Small fix](https://github.com/mirage/irmin) by [@Bactrian](https://github.com/Bactrian)
+ - PR: Small fix [mirage/irmin#2210](https://github.com/mirage/irmin/issues/2210) by [@Bactrian](https://github.com/Bactrian)
 
    (created: 2021-02-01T00:00:00Z, reviewed by: [@Dromedary](https://github.com/Dromedary))
    Fixes a small thing
@@ -13,7 +13,7 @@ Irmin is a distributed database that follows the same design principles as Git
 
 #### Merged
 
- - [Smaller fix](https://github.com/mirage/irmin) by [@Bactrian](https://github.com/Bactrian)
+ - PR: Smaller fix [mirage/irmin#2220](https://github.com/mirage/irmin/issues/2220) by [@Bactrian](https://github.com/Bactrian)
 
    (merged: 2021-02-01T00:00:02Z, reviewed by: [@Dromedary](https://github.com/Dromedary))
    Fixes a really small thing
@@ -21,5 +21,5 @@ Irmin is a distributed database that follows the same design principles as Git
 
 ### Issues
 
- - [Small bug](https://github.com/mirage/irmin) by @Dromedary (created/merged: 2021-01-27T00:00:00Z)
+ - Issue: Small bug [mirage/irmin#2200](https://github.com/mirage/irmin/issues/2200)  by @Dromedary (created/merged: 2021-01-27T00:00:00Z)
    A small bug

--- a/test/expect/test_monthly.ml
+++ b/test/expect/test_monthly.ml
@@ -35,7 +35,7 @@ let repo_report =
                 author = Some "Dromedary";
                 title = "Small bug";
                 cursor = "wkjgkdjlsghwkl";
-                url = "https://github.com/mirage/irmin";
+                url = "https://github.com/mirage/irmin/issues/2200";
                 body = "A small bug";
                 closed = false;
                 closed_at = None;
@@ -48,7 +48,7 @@ let repo_report =
               {
                 author = Some "Bactrian";
                 cursor = "ABCDEFGHIJKLM";
-                url = "https://github.com/mirage/irmin";
+                url = "https://github.com/mirage/irmin/issues/2210";
                 title = "Small fix";
                 body = "Fixes a small thing";
                 closed = false;
@@ -62,7 +62,7 @@ let repo_report =
               {
                 author = Some "Bactrian";
                 cursor = "ZYXW";
-                url = "https://github.com/mirage/irmin";
+                url = "https://github.com/mirage/irmin/issues/2220";
                 title = "Smaller fix";
                 body = "Fixes a really small thing";
                 closed = false;


### PR DESCRIPTION
Fix #194 

There is code duplication for now, ultimately the code retrieving the repo activity should be moved to `get-activity` so we can refactor there and use the same types.

@rikusilvola let me know how this formatting looks