### PR TITLE
Allow time submitted in days and in hours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Improve the "Invalid time" error messages (#199, @gpetiot)
 - okra team lint: only print details of invalid/missing files, or total of valid files (#200, @gpetiot)
 - okra gen report: PR/issue entries formatted the same way as in engineer reports (#201, @gpetiot)
+- Allow to report time in hours, mixing days with hours causes the aggregates to use hours (#205, @gpetiot)
 
 ### Fixed
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -65,7 +65,7 @@ let time_entry_regexp =
     let without_int_part = seq [ str ".5"; opt (char '0') ] in
     group (alt [ with_int_part; without_int_part ])
   in
-  let time_unit = group (alt [ str "day" ]) in
+  let time_unit = group (alt [ str "day"; str "hour" ]) in
   let time = seq [ number; rep space; time_unit; opt (char 's') ] in
   compile @@ seq [ start; user; rep space; char '('; time; char ')'; stop ]
 

--- a/lib/time.mli
+++ b/lib/time.mli
@@ -1,5 +1,5 @@
 module Unit : sig
-  type t = Day
+  type t = Day | Hour
 
   val of_string : string -> t option
 end
@@ -8,6 +8,7 @@ type t = { data : float; unit : Unit.t }
 
 val nil : t
 val days : float -> t
+val hours : float -> t
 val equal : t -> t -> bool
 val add : t -> t -> t
 val ( +. ) : t -> t -> t

--- a/test/aggregate/valid-time1.acc
+++ b/test/aggregate/valid-time1.acc
@@ -3,7 +3,7 @@
 ## Objective
 
 - This is a WI (#123)
-  - @eng6 (1 day)
+  - @eng6 (2.5 hours)
   - My work
 
 - This is a KR (KR123)
@@ -23,7 +23,7 @@
   - My work
 
 - Another KR (KR125)
-  - @eng3 (3.5 days), @eng4 (0.5 day)
+  - @eng3 (3.5 hours), @eng4 (0.5 day)
   - Work
 
 - This is a KR (KR124)
@@ -33,7 +33,7 @@
 ## New title
 
 - Another KR (KR125)
-  - @eng3 (1.5 days), @eng4 (1 day)
+  - @eng3 (1.5 hours), @eng4 (1 day)
   - Work
 
 - Last KR (new KR)

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -132,6 +132,31 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   > # Last week
   > 
   > - This is a KR (KR1)
+  >   - @eng1 (1.1 hours)
+  >   - My work
+  > 
+  > # Activity
+  > 
+  > More unformatted text.
+  > EOF
+  [ERROR(S)]: <stdin>
+  
+  In KR "This is a KR":
+    Invalid time entry "@eng1 (1.1 hours)" found. Format is '- @eng1 (x days), @eng2 (y days)'
+    where x and y must be divisible by 0.5
+  [1]
+
+  $ okra lint --engineer << EOF
+  > # Projects
+  > 
+  > - Project1 (KR1)
+  > - Project2 (KR2)
+  > 
+  > This is not formatted.
+  > 
+  > # Last week
+  > 
+  > - This is a KR (KR1)
   >   - @eng1 ( day)
   >   - My work
   > 
@@ -143,5 +168,30 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   
   In KR "This is a KR":
     Invalid time entry "@eng1 ( day)" found. Format is '- @eng1 (x days), @eng2 (y days)'
+    where x and y must be divisible by 0.5
+  [1]
+
+  $ okra lint --engineer << EOF
+  > # Projects
+  > 
+  > - Project1 (KR1)
+  > - Project2 (KR2)
+  > 
+  > This is not formatted.
+  > 
+  > # Last week
+  > 
+  > - This is a KR (KR1)
+  >   - @eng1 ( hour)
+  >   - My work
+  > 
+  > # Activity
+  > 
+  > More unformatted text.
+  > EOF
+  [ERROR(S)]: <stdin>
+  
+  In KR "This is a KR":
+    Invalid time entry "@eng1 ( hour)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]

--- a/test/cram/lint/time.t
+++ b/test/cram/lint/time.t
@@ -56,13 +56,27 @@ Invalid time
     where x and y must be divisible by 0.5
   [1]
 
+  $ okra lint << EOF
+  > # Title
+  > 
+  > - This is a KR (KR123)
+  >   - @eng1 (. hours)
+  >   - My work
+  > EOF
+  [ERROR(S)]: <stdin>
+  
+  In KR "This is a KR":
+    Invalid time entry "@eng1 (. hours)" found. Format is '- @eng1 (x days), @eng2 (y days)'
+    where x and y must be divisible by 0.5
+  [1]
+
 Valid time
 
   $ okra lint << EOF
   > # Title
   > 
   > - This is a KR (KR123)
-  >   - @eng1 (.5 day)
+  >   - @eng1 (.5 hours)
   >   - My work
   > 
   > - This is a KR (KR124)
@@ -78,7 +92,9 @@ Valid time
   >   - My work
   > 
   > - This is a KR (KR124)
-  >   - @eng1 (1.5 days), @eng1 (.5 day)
+  >   - @eng1 (1.5 days), @eng1 (.5 hours)
   >   - My work
   > EOF
+  okra: [WARNING] converting days metric into hours (considering 8h/day)
+  okra: [WARNING] converting days metric into hours (considering 8h/day)
   [OK]: <stdin>

--- a/test/cram/team-aggregate.t/admin/weekly/2022/41/eng1.md
+++ b/test/cram/team-aggregate.t/admin/weekly/2022/41/eng1.md
@@ -1,7 +1,7 @@
 # Last Week
 
 - A KR (KR123)
-  - @eng1 (1 day)
+  - @eng1 (10 hours)
   - Work 1
 - A KR (KR100)
   - @eng1 (1 day)

--- a/test/cram/team-aggregate.t/run.t
+++ b/test/cram/team-aggregate.t/run.t
@@ -9,7 +9,7 @@ Team aggregate example
     - Work 1
   
   - A KR (KR123)
-    - @eng1 (1 day), @eng2 (1 day)
+    - @eng1 (10 hours), @eng2 (1 day)
     - Work 1
     - Work 1
   
@@ -23,7 +23,7 @@ Only select a few okrs
   # Last Week
   
   - A KR (KR123)
-    - @eng1 (1 day), @eng2 (1 day)
+    - @eng1 (10 hours), @eng2 (1 day)
     - Work 1
     - Work 1
   
@@ -43,6 +43,7 @@ Exclude a few okrs
 Multiple weeks
 
   $ okra team aggregate -C admin/ -w 40-41 -y 2022 --conf ./conf.yml
+  okra: [WARNING] converting days metric into hours (considering 8h/day)
   # Last Week
   
   - A KR (KR100)
@@ -51,7 +52,7 @@ Multiple weeks
     - Work 1
   
   - A KR (KR123)
-    - @eng1 (2 days), @eng2 (2 days)
+    - @eng1 (18 hours), @eng2 (2 days)
     - Work 1
     - Work 1
     - Work 1

--- a/test/test_aggregate.ml
+++ b/test/test_aggregate.ml
@@ -33,13 +33,13 @@ let test_time_parsing f () =
   Alcotest.(check Alcotest_ext.time)
     "eng1 time" (T.days 3.0) (Hashtbl.find res "eng1");
   Alcotest.(check Alcotest_ext.time)
-    "eng3 time" (T.days 5.0) (Hashtbl.find res "eng3");
+    "eng3 time" (T.hours 5.0) (Hashtbl.find res "eng3");
   Alcotest.(check Alcotest_ext.time)
     "eng4 time" (T.days 1.5) (Hashtbl.find res "eng4");
   Alcotest.(check Alcotest_ext.time)
     "eng5 time" (T.days 21.0) (Hashtbl.find res "eng5");
   Alcotest.(check Alcotest_ext.time)
-    "eng6 time" (T.days 1.0) (Hashtbl.find res "eng6")
+    "eng6 time" (T.hours 2.5) (Hashtbl.find res "eng6")
 
 let tests =
   [


### PR DESCRIPTION
This one is a request for comments.

It has been discussed in #178 that some users track their own time in hours, and the time is tracked by tarides and billed in hours.

This PR allows:
- reporting in hours
- reporting in days
- mixing both (the aggregates convert in hours (maybe we should convert in days instead since reports don't need to be that precise? but there is a warning)

@ganeshn-gh (cc @kc @GemmaG) can I have your opinion? Would reporting time in hours make it easier for you?
There is no check on the total amount of hours being reported by the user (but we check that its granularity is .5) as it depends on the type of contract.
For the same reason, days are converted in hours using 8h/day, but that should only impact the team aggregate feature, so no impact for the lint.

@rikusilvola @jmid can I have your opinion on how it would affect the team aggregate workflow for you?
