### PR TITLE
Define proper time datatype

### DIFF
--- a/bin/stats.ml
+++ b/bin/stats.ml
@@ -27,7 +27,7 @@ let sort_by_days l =
 
 let green = Fmt.(styled `Green string)
 let cyan = Fmt.(styled `Cyan string)
-let pp_days ppf d = Fmt.(styled `Bold string) ppf (KR.string_of_days d)
+let pp_days ppf d = Fmt.(styled `Bold Time.pp) ppf d
 
 let print kind t =
   match kind with

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -33,8 +33,8 @@ type t = private {
   objective : string;
   title : string;
   id : id;
-  time_entries : (string * float) list list;
-  time_per_engineer : (string, float) Hashtbl.t;
+  time_entries : (string * Time.t) list list;
+  time_per_engineer : (string, Time.t) Hashtbl.t;
   work : Item.t list list;
 }
 
@@ -43,7 +43,7 @@ val v :
   objective:string ->
   title:string ->
   id:id ->
-  time_entries:(string * float) list list ->
+  time_entries:(string * Time.t) list list ->
   Item.t list list ->
   t
 
@@ -53,8 +53,6 @@ val compare : t -> t -> int
 val update_from_master_db : t -> Masterdb.t -> t
 
 (** {2 Pretty-print} *)
-
-val string_of_days : float -> string
 
 val items :
   ?show_time:bool ->

--- a/lib/aggregate.ml
+++ b/lib/aggregate.ml
@@ -18,7 +18,7 @@
 let ht_add_or_sum ht k v =
   match Hashtbl.find_opt ht k with
   | None -> Hashtbl.add ht k v
-  | Some x -> Hashtbl.replace ht k (Float.add v x)
+  | Some x -> Hashtbl.replace ht k (Time.add v x)
 
 let by_ f ?(include_krs = []) t =
   let uppercase_include_krs = List.map String.uppercase_ascii include_krs in
@@ -44,20 +44,23 @@ let by_engineer =
 let by_kr =
   by_ (fun result e ->
       let time =
-        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer 0.
+        let open Time in
+        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer nil
       in
       Hashtbl.add result (e.title, e.id) time)
 
 let by_objective =
   by_ (fun result e ->
       let time =
-        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer 0.
+        let open Time in
+        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer nil
       in
       ht_add_or_sum result e.objective time)
 
 let by_project =
   by_ (fun result e ->
       let time =
-        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer 0.
+        let open Time in
+        Hashtbl.fold (fun _ w acc -> acc +. w) e.time_per_engineer nil
       in
       ht_add_or_sum result e.project time)

--- a/lib/aggregate.mli
+++ b/lib/aggregate.mli
@@ -16,13 +16,13 @@
  *)
 
 val by_engineer :
-  ?include_krs:string list -> Report.t -> (string, float) Hashtbl.t
+  ?include_krs:string list -> Report.t -> (string, Time.t) Hashtbl.t
 
 val by_kr :
-  ?include_krs:string list -> Report.t -> (string * KR.id, float) Hashtbl.t
+  ?include_krs:string list -> Report.t -> (string * KR.id, Time.t) Hashtbl.t
 
 val by_objective :
-  ?include_krs:string list -> Report.t -> (string, float) Hashtbl.t
+  ?include_krs:string list -> Report.t -> (string, Time.t) Hashtbl.t
 
 val by_project :
-  ?include_krs:string list -> Report.t -> (string, float) Hashtbl.t
+  ?include_krs:string list -> Report.t -> (string, Time.t) Hashtbl.t

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -65,7 +65,8 @@ let time_entry_regexp =
     let without_int_part = seq [ str ".5"; opt (char '0') ] in
     group (alt [ with_int_part; without_int_part ])
   in
-  let time = seq [ number; rep space; str "day"; opt (char 's') ] in
+  let time_unit = group (alt [ str "day" ]) in
+  let time = seq [ number; rep space; time_unit; opt (char 's') ] in
   compile @@ seq [ start; user; rep space; char '('; time; char ')'; stop ]
 
 let is_suffix suffix s =
@@ -204,7 +205,10 @@ let kr ~project ~objective = function
                       let* user = Re.Group.get_opt grp 1 in
                       let* s_time = Re.Group.get_opt grp 2 in
                       let* f_time = Float.of_string_opt s_time in
-                      Some (user, f_time)
+                      let* s_unit = Re.Group.get_opt grp 3 in
+                      let* t_unit = Time.Unit.of_string s_unit in
+                      let time = { Time.unit = t_unit; data = f_time } in
+                      Some (user, time)
                     with
                     | Some x -> Some x
                     | None ->

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -1,0 +1,30 @@
+module Unit = struct
+  type t = Day
+
+  let of_string = function "day" -> Some Day | _ -> None
+  let equal x y = match (x, y) with Day, Day -> true
+  let pp fs = function Day -> Fmt.pf fs "day"
+end
+
+type t = { data : float; unit : Unit.t }
+
+let equal x y =
+  if Unit.equal x.unit y.unit then Float.equal x.data y.data
+  else x.data = 0. && y.data = 0.
+
+let nil = { unit = Day; data = 0. }
+let days data = { unit = Day; data }
+
+let add x y =
+  match (x.unit, y.unit) with
+  | Day, Day -> { unit = x.unit; data = x.data +. y.data }
+
+let ( +. ) = add
+
+let pp fs { unit; data } =
+  let pp_float fs f =
+    if classify_float (fst (modf f)) = FP_zero then Fmt.pf fs "%.0f" f
+    else Fmt.pf fs "%.1f" f
+  in
+  if data = 1. then Fmt.pf fs "1 %a" Unit.pp unit
+  else Fmt.pf fs "%a %as" pp_float data Unit.pp unit

--- a/lib/time.mli
+++ b/lib/time.mli
@@ -1,0 +1,14 @@
+module Unit : sig
+  type t = Day
+
+  val of_string : string -> t option
+end
+
+type t = { data : float; unit : Unit.t }
+
+val nil : t
+val days : float -> t
+val equal : t -> t -> bool
+val add : t -> t -> t
+val ( +. ) : t -> t -> t
+val pp : t Fmt.t

--- a/test/alcotest_ext.ml
+++ b/test/alcotest_ext.ml
@@ -1,0 +1,1 @@
+let time = Alcotest.testable Okra.Time.pp Okra.Time.equal

--- a/test/alcotest_ext.mli
+++ b/test/alcotest_ext.mli
@@ -1,0 +1,1 @@
+val time : Okra.Time.t Alcotest.testable

--- a/test/test_aggregate.ml
+++ b/test/test_aggregate.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module T = Okra.Time
+
 let aggregate f =
   let ic = open_in f in
   let omd = Omd.of_channel ic in
@@ -28,11 +30,16 @@ let aggregate_by_engineer f =
 
 let test_time_parsing f () =
   let res = aggregate_by_engineer f in
-  Alcotest.(check (float 0.0)) "eng1 time" 3.0 (Hashtbl.find res "eng1");
-  Alcotest.(check (float 0.0)) "eng3 time" 5.0 (Hashtbl.find res "eng3");
-  Alcotest.(check (float 0.0)) "eng4 time" 1.5 (Hashtbl.find res "eng4");
-  Alcotest.(check (float 0.0)) "eng5 time" 21.0 (Hashtbl.find res "eng5");
-  Alcotest.(check (float 0.0)) "eng6 time" 1.0 (Hashtbl.find res "eng6")
+  Alcotest.(check Alcotest_ext.time)
+    "eng1 time" (T.days 3.0) (Hashtbl.find res "eng1");
+  Alcotest.(check Alcotest_ext.time)
+    "eng3 time" (T.days 5.0) (Hashtbl.find res "eng3");
+  Alcotest.(check Alcotest_ext.time)
+    "eng4 time" (T.days 1.5) (Hashtbl.find res "eng4");
+  Alcotest.(check Alcotest_ext.time)
+    "eng5 time" (T.days 21.0) (Hashtbl.find res "eng5");
+  Alcotest.(check Alcotest_ext.time)
+    "eng6 time" (T.days 1.0) (Hashtbl.find res "eng6")
 
 let tests =
   [

--- a/test/test_filter.ml
+++ b/test/test_filter.ml
@@ -16,6 +16,7 @@
  *)
 
 open Okra
+module T = Okra.Time
 
 let p1 = "Project 1"
 let p2 = "Project 2"
@@ -27,9 +28,9 @@ let t3 = "title3"
 let e1 = "foo"
 let e2 = "bar"
 let e3 = "john"
-let te1 = [ [ (e1, 1.) ]; [ (e1, 2.); (e2, 2.) ] ]
-let te2 = [ [ (e1, 10.) ] ]
-let te3 = [ [ (e2, 10.) ]; [ (e3, 5.) ] ]
+let te1 = [ [ (e1, T.days 1.) ]; [ (e1, T.days 2.); (e2, T.days 2.) ] ]
+let te2 = [ [ (e1, T.days 10.) ] ]
+let te3 = [ [ (e2, T.days 10.) ]; [ (e3, T.days 5.) ] ]
 let id2 = "Id2"
 let id3 = "ID3"
 
@@ -141,9 +142,9 @@ let test_exclude_engineers () =
 
   let t2 = filter t ~include_krs:[ ID id3 ] ~include_engineers:[ e2 ] in
   let kr = get_kr t2 in
-  Alcotest.(check (list (list (pair string (float 0.)))))
+  Alcotest.(check (list (list (pair string Alcotest_ext.time))))
     "check time entries"
-    [ [ (e2, 10.) ] ]
+    [ [ (e2, T.days 10.) ] ]
     kr.KR.time_entries
 
 let tests =

--- a/test/test_reports.ml
+++ b/test/test_reports.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module T = Okra.Time
+
 let aggregate f =
   let ic = open_in f in
   let omd = Omd.of_channel ic in
@@ -41,7 +43,8 @@ let test_newkr_exists1 () =
   let res = aggregate "./reports/newkr_exists1.acc" in
   Alcotest.(check bool) "new KR exists" true (contains_kr res New_KR);
   let res = Okra.Aggregate.by_engineer res in
-  Alcotest.(check (float 0.0)) "eng1 time" 1.0 (Hashtbl.find res "eng1")
+  Alcotest.(check Alcotest_ext.time)
+    "eng1 time" (T.days 1.0) (Hashtbl.find res "eng1")
 
 let test_kr_agg1 () =
   let res = aggregate "./reports/kr_agg1.acc" in
@@ -51,13 +54,15 @@ let test_kr_agg1 () =
     (contains_kr_cnt res (ID "KR123"));
   let res = Okra.Aggregate.by_engineer res in
   (* also check that time adds up *)
-  Alcotest.(check (float 0.0)) "eng1 time" 4.0 (Hashtbl.find res "eng1")
+  Alcotest.(check Alcotest_ext.time)
+    "eng1 time" (T.days 4.0) (Hashtbl.find res "eng1")
 
 let test_work_item () =
   let res = aggregate "./reports/work_item.acc" in
   Alcotest.(check bool) "#123 exists" true (contains_kr res (ID "#123"));
   let res = Okra.Aggregate.by_engineer res in
-  Alcotest.(check (float 0.0)) "eng1 time" 1.0 (Hashtbl.find res "eng1")
+  Alcotest.(check Alcotest_ext.time)
+    "eng1 time" (T.days 1.0) (Hashtbl.find res "eng1")
 
 let tests =
   [


### PR DESCRIPTION
Extracted from #205: defining a proper datatype for the time (with only one unit "days") without changing any behavior.

I think it's cleaner than having floats with implicit units, and it makes it easier to allow different units in the future.