### PR TITLE
okra gen: only list comments when there is no other activity on the same issue/PR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,8 @@
 - okra gen report: PR/issue entries formatted the same way as in engineer reports (#201, @gpetiot)
 - List of projects not printed by default anymore in generated reports (#212, @gpetiot).
   Use the new option `--print-projects` to display the list.
-- okra gen: Group activity items together when possible (#208, @gpetiot)
+- okra gen: Group activity items together when possible (#208, @gpetiot).
+  Comments are only listed when there is no other activity on the same issue/PR.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - okra gen report: PR/issue entries formatted the same way as in engineer reports (#201, @gpetiot)
 - List of projects not printed by default anymore in generated reports (#212, @gpetiot).
   Use the new option `--print-projects` to display the list.
+- okra gen: Group activity items together when possible (#<PR_NUMBER>, @gpetiot)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - okra gen report: PR/issue entries formatted the same way as in engineer reports (#201, @gpetiot)
 - List of projects not printed by default anymore in generated reports (#212, @gpetiot).
   Use the new option `--print-projects` to display the list.
-- okra gen: Group activity items together when possible (#<PR_NUMBER>, @gpetiot)
+- okra gen: Group activity items together when possible (#208, @gpetiot)
 
 ### Fixed
 

--- a/lib/activity.ml
+++ b/lib/activity.ml
@@ -50,12 +50,6 @@ let repo_org ?(with_id = false) ?(no_links = false) f s =
 
 let pp_ga_item ?(gitlab = false) ~no_links sub_items f
     (t : Get_activity.Contributions.item) =
-  let comments =
-    match sub_items with
-    | [] -> ""
-    | [ _ ] -> Format.sprintf " (+ 1 comment)"
-    | _ -> Format.sprintf " (+ %i comments)" (List.length sub_items)
-  in
   match gitlab with
   | true -> (
       match t.kind with
@@ -65,7 +59,7 @@ let pp_ga_item ?(gitlab = false) ~no_links sub_items f
   | false -> (
       match t.kind with
       | `Issue ->
-          Fmt.pf f "Opened issue%s: %s %a" comments t.title
+          Fmt.pf f "Opened issue: %s %a" t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `PR ->
@@ -75,7 +69,7 @@ let pp_ga_item ?(gitlab = false) ~no_links sub_items f
               sub_items
           in
           let status = if merged then "Opened and merged" else "Opened" in
-          Fmt.pf f "%s PR%s: %s %a" status comments t.title
+          Fmt.pf f "%s PR: %s %a" status t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Comment `Issue ->
@@ -91,13 +85,13 @@ let pp_ga_item ?(gitlab = false) ~no_links sub_items f
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Review s ->
-          Fmt.pf f "%s PR%s: %s %a"
+          Fmt.pf f "%s PR: %s %a"
             (String.capitalize_ascii @@ String.lowercase_ascii s)
-            comments t.title
+            t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Merge ->
-          Fmt.pf f "Merged PR%s: %s %a" comments t.title
+          Fmt.pf f "Merged PR: %s %a" t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `New_repo ->

--- a/lib/activity.ml
+++ b/lib/activity.ml
@@ -21,6 +21,10 @@ let title { title; _ } = title
 
 type t = { projects : project list; activity : Get_activity.Contributions.t }
 
+let pp_kind ppf = function
+  | `Issue -> Fmt.sp ppf "issue"
+  | `PR -> Fmt.sp ppf "PR"
+
 let pp_last_week username ppf projects =
   let pp_items ppf t =
     let t = if t = [] then [ "Work Item 1" ] else t in
@@ -72,16 +76,10 @@ let pp_ga_item ?(gitlab = false) ~no_links sub_items f
           Fmt.pf f "%s PR: %s %a" status t.title
             (repo_org ~with_id:true ~no_links)
             t.url
-      | `Comment `Issue ->
-          Fmt.pf f "Commented (%i) on issue: %s %a"
+      | `Comment kind ->
+          Fmt.pf f "Commented (%i) on %a: %s %a"
             (List.length sub_items + 1)
-            t.title
-            (repo_org ~with_id:true ~no_links)
-            t.url
-      | `Comment `PR ->
-          Fmt.pf f "Commented (%i) on PR: %s %a"
-            (List.length sub_items + 1)
-            t.title
+            pp_kind kind t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Review s ->

--- a/lib/activity.ml
+++ b/lib/activity.ml
@@ -140,9 +140,7 @@ let pp_ga_item ?(gitlab = false) ~no_links sub_items f
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Comment kind ->
-          Fmt.pf f "Commented (%i) on %a: %s %a"
-            (List.length sub_items + 1)
-            pp_kind kind t.title
+          Fmt.pf f "Commented on %a: %s %a" pp_kind kind t.title
             (repo_org ~with_id:true ~no_links)
             t.url
       | `Review s ->

--- a/lib/activity.mli
+++ b/lib/activity.mli
@@ -27,11 +27,6 @@ val repo_org :
   ?with_id:bool -> ?no_links:bool -> Format.formatter -> string -> unit
 (** [report_org fs url] pretty-prints [url] in the form [repo/id]. *)
 
-val pp_ga_item :
-  ?gitlab:bool -> no_links:bool -> unit -> Get_activity.Contributions.item Fmt.t
-(** [pp_ga_item ?gitlab ~no_links () ppf item] prints the get-activity item. See
-    the description of [gitlab] and [no_links] in {!pp}. *)
-
 val pp_activity :
   ?gitlab:bool ->
   no_links:bool ->

--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -6,8 +6,8 @@
 
 # Activity (move these items to last week)
 
-  - PR: Fix bug in Okra [bactrian/okra#42](https://github.com/bactrian/okra/pull/42)
-  - PR: Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43)
-  - Issue: There's a bug in Okra [bactrian/okra#26](https://github.com/bactrian/okra/issue/26)
-  - APPROVED Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43#pullrequestreview-123456789)
   - Created repository [bactrian/okra-web](https://github.com/bactrian/okra-web)
+  - Opened issue: There's a bug in Okra [bactrian/okra#26](https://github.com/bactrian/okra/issue/26)
+  - Opened PR: Fix bug in Okra [bactrian/okra#42](https://github.com/bactrian/okra/pull/42)
+  - Opened PR: Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43)
+  - Approved PR: Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43#pullrequestreview-123456789)


### PR DESCRIPTION
Fix #191

The goal of this PR is to reduce the size of the generated activity, by merging related items whenever possible (i.e. if they have been created during the same activity period of course).

e.g.
- comments are attached to the created issue, created PR, review or merge events
- merge events are attached to the created PR.

Also, I wanted the activity to be easier to read, so the items have been normalized:
- Opened issue: ...
- Opened PR: ...
- Opened and merged PR: ...
- Approved/Rejected PR: ...
- Merged PR: ...
- Commented on issue: ...
- Commented on PR: ...

What do you think? Would that reduce the edits on the weeklies?
@jmid @kayceesrk @rikusilvola @shindere