### PR TITLE
Make github handles clickable in generated engineer reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#210, @gpetiot)
 - Make github handles clickable in repo reports (#193, #207, @gpetiot)
-- Make github handles clickable in generated engineer reports (#<PR_NUMBER>, @gpetiot)
+- Make github handles clickable in generated engineer reports (#209, @gpetiot)
 - Parser collects all issues instead of raising an exception (#195, @gpetiot).
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
 - Improve the "Invalid time" error messages (#199, @gpetiot)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#210, @gpetiot)
 - Make github handles clickable in repo reports (#193, #207, @gpetiot)
+- Make github handles clickable in generated engineer reports (#<PR_NUMBER>, @gpetiot)
 - Parser collects all issues instead of raising an exception (#195, @gpetiot).
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
 - Improve the "Invalid time" error messages (#199, @gpetiot)

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -173,8 +173,8 @@ let compare a b =
   | _ -> compare_no_case a.title b.title
 
 let make_engineer ~time (e, d) =
-  let pp_user ppf u = Fmt.pf ppf "[@%s](https://github.com/%s)" u u in
-  if time then Fmt.str "%a (%a)" pp_user e Time.pp d else Fmt.str "%a" pp_user e
+  if time then Fmt.str "%a (%a)" (User.pp ~with_link:true) e Time.pp d
+  else Fmt.str "%a" (User.pp ~with_link:true) e
 
 let make_engineers ~time entries =
   let entries = List.of_seq (Hashtbl.to_seq entries) in

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -173,7 +173,8 @@ let compare a b =
   | _ -> compare_no_case a.title b.title
 
 let make_engineer ~time (e, d) =
-  if time then Fmt.str "@%s (%a)" e Time.pp d else Printf.sprintf "@%s" e
+  let pp_user ppf u = Fmt.pf ppf "[@%s](https://github.com/%s)" u u in
+  if time then Fmt.str "%a (%a)" pp_user e Time.pp d else Fmt.str "%a" pp_user e
 
 let make_engineers ~time entries =
   let entries = List.of_seq (Hashtbl.to_seq entries) in

--- a/lib/activity.ml
+++ b/lib/activity.ml
@@ -27,7 +27,12 @@ let pp_last_week username ppf projects =
     Fmt.(pf ppf "%a" (list (fun ppf s -> Fmt.pf ppf "  - %s" s))) t
   in
   let pp_project ppf { title; items } =
-    Fmt.pf ppf "- %s\n  - @%s (<X> days)\n%a@." title username pp_items items
+    let pp_user ppf = function
+      | "<USERNAME>" as u -> Fmt.pf ppf "@%s" u
+      | u -> Fmt.pf ppf "[@%s](https://github.com/%s)" u u
+    in
+    Fmt.pf ppf "- %s\n  - %a (<X> days)\n%a@." title pp_user username pp_items
+      items
   in
   Fmt.pf ppf "%a" Fmt.(list ~sep:(cut ++ cut) pp_project) projects
 

--- a/lib/activity.ml
+++ b/lib/activity.ml
@@ -21,7 +21,7 @@ let title { title; _ } = title
 
 type t = { projects : project list; activity : Get_activity.Contributions.t }
 
-let pp_last_week username ppf projects =
+let pp_last_week ?(no_links = false) username ppf projects =
   let pp_items ppf t =
     let t = if t = [] then [ "Work Item 1" ] else t in
     Fmt.(pf ppf "%a" (list (fun ppf s -> Fmt.pf ppf "  - %s" s))) t
@@ -29,7 +29,7 @@ let pp_last_week username ppf projects =
   let pp_project ppf { title; items } =
     let pp_user ppf = function
       | "<USERNAME>" as u -> Fmt.pf ppf "@%s" u
-      | u -> Fmt.pf ppf "[@%s](https://github.com/%s)" u u
+      | u -> User.pp ppf ~with_link:(not no_links) u
     in
     Fmt.pf ppf "- %s\n  - %a (<X> days)\n%a@." title pp_user username pp_items
       items
@@ -116,7 +116,9 @@ let pp ?(gitlab = false) ?(no_links = false) () ppf
 %a
 |}
     Fmt.(list ~sep:newline (fun ppf s -> Fmt.pf ppf "- %s" s))
-    (List.map title projects) (pp_last_week username) projects
+    (List.map title projects)
+    (pp_last_week ~no_links username)
+    projects
     (pp_activity ~gitlab ~no_links ())
     activity
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -59,17 +59,17 @@ let is_time_block = function
       String.get (String.trim s) 0 = '@'
   | _ -> false
 
-let user_url_regexp =
+let user_url_regexp ~extract =
   let open Re in
+  let maybe_group = if extract then group ?name:None else fun x -> x in
   let username = rep1 (alt [ wordc; char '-' ]) in
-  let txt = seq [ char '@'; group username ] in
+  let txt = seq [ char '@'; maybe_group username ] in
   let url = seq [ str "https://github.com/"; username ] in
-  compile
-  @@ seq [ start; char '['; txt; char ']'; char '('; url; char ')'; stop ]
+  seq [ char '['; txt; char ']'; char '('; url; char ')' ]
 
 let user_of_string s =
   let default = String.sub s 1 (String.length s - 1) in
-  match Re.exec_opt user_url_regexp s with
+  match Re.exec_opt (Re.compile (user_url_regexp ~extract:true)) s with
   | Some grp -> Option.value (Re.Group.get_opt grp 1) ~default
   | None -> default
 
@@ -77,11 +77,7 @@ let time_entry_regexp =
   let open Re in
   let user =
     let username = rep1 (alt [ wordc; char '-' ]) in
-    let with_url =
-      let txt = seq [ char '@'; username ] in
-      let url = seq [ str "https://github.com/"; username ] in
-      seq [ char '['; txt; char ']'; char '('; url; char ')' ]
-    in
+    let with_url = user_url_regexp ~extract:false in
     let without_url = seq [ char '@'; username ] in
     group (alt [ with_url; without_url ])
   in

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -50,12 +50,41 @@ let obj_re = Str.regexp "\\(.+\\) (\\([a-zA-Z ]+\\))$"
 (* Header: This is an objective (Tech lead name) *)
 
 let is_time_block = function
-  | [ Paragraph (_, Text (_, s)) ] -> String.get (String.trim s) 0 = '@'
+  | [
+      Paragraph
+        ( _,
+          (Text (_, s) | Concat (_, Link (_, { label = Text (_, s); _ }) :: _))
+        );
+    ] ->
+      String.get (String.trim s) 0 = '@'
   | _ -> false
+
+let user_url_regexp =
+  let open Re in
+  let username = rep1 (alt [ wordc; char '-' ]) in
+  let txt = seq [ char '@'; group username ] in
+  let url = seq [ str "https://github.com/"; username ] in
+  compile
+  @@ seq [ start; char '['; txt; char ']'; char '('; url; char ')'; stop ]
+
+let user_of_string s =
+  let default = String.sub s 1 (String.length s - 1) in
+  match Re.exec_opt user_url_regexp s with
+  | Some grp -> Option.value (Re.Group.get_opt grp 1) ~default
+  | None -> default
 
 let time_entry_regexp =
   let open Re in
-  let user = seq [ char '@'; group (rep1 (alt [ wordc; char '-' ])) ] in
+  let user =
+    let username = rep1 (alt [ wordc; char '-' ]) in
+    let with_url =
+      let txt = seq [ char '@'; username ] in
+      let url = seq [ str "https://github.com/"; username ] in
+      seq [ char '['; txt; char ']'; char '('; url; char ')' ]
+    in
+    let without_url = seq [ char '@'; username ] in
+    group (alt [ with_url; without_url ])
+  in
   let number =
     let with_int_part =
       let int_part = rep1 digit in
@@ -203,6 +232,7 @@ let kr ~project ~objective = function
                     match
                       let* grp = Re.exec_opt time_entry_regexp s in
                       let* user = Re.Group.get_opt grp 1 in
+                      let user = user_of_string user in
                       let* s_time = Re.Group.get_opt grp 2 in
                       let* f_time = Float.of_string_opt s_time in
                       let* s_unit = Re.Group.get_opt grp 3 in

--- a/lib/repo_report.ml
+++ b/lib/repo_report.ml
@@ -58,7 +58,7 @@ module Issue = struct
 
   let pp ~with_names ~with_times ~with_descriptions ppf
       { author; title; url; created_at; body; _ } =
-    let pp_user ppf u = Fmt.pf ppf "[@%s](https://github.com/%s)" u u in
+    let pp_user = User.pp ~with_link:true in
     let pp_created_at ppf = Fmt.pf ppf " (created/merged: %s)" in
     let pp_author ppf = Fmt.pf ppf " by %a" pp_user in
     Fmt.(
@@ -149,7 +149,7 @@ module PR = struct
 
   let pp ~with_names ~with_times ~with_descriptions ppf
       { author; title; url; created_at; merged_at; reviewers; body; _ } =
-    let pp_user ppf u = Fmt.pf ppf "[@%s](https://github.com/%s)" u u in
+    let pp_user = User.pp ~with_link:true in
     let pp_created_at ppf = Fmt.pf ppf " (created/merged: %s)" in
     let pp_author ppf = Fmt.pf ppf " by %a" pp_user in
     let reviewers =
@@ -175,7 +175,7 @@ module PR = struct
           (Option.value ~default:"No author" author)
           (Option.value ~default:("created: " ^ created_at)
              (Option.map (( ^ ) "merged: ") merged_at))
-          Fmt.(list ~sep:(fun ppf _ -> Fmt.pf ppf ", ") pp_user)
+          (Fmt.list ~sep:(fun ppf _ -> Fmt.pf ppf ", ") pp_user)
           reviewers (option string)
           (if not with_descriptions then None else Some body))
 

--- a/lib/user.ml
+++ b/lib/user.ml
@@ -1,0 +1,26 @@
+type t = string
+
+let md_url_regexp ~extract =
+  let open Re in
+  let maybe_group = if extract then group ?name:None else fun x -> x in
+  let username = rep1 (alt [ wordc; char '-' ]) in
+  let txt = seq [ char '@'; maybe_group username ] in
+  let url = seq [ str "https://github.com/"; username ] in
+  seq [ char '['; txt; char ']'; char '('; url; char ')' ]
+
+let regexp =
+  let open Re in
+  let username = rep1 (alt [ wordc; char '-' ]) in
+  let with_url = md_url_regexp ~extract:false in
+  let without_url = seq [ char '@'; username ] in
+  alt [ with_url; without_url ]
+
+let of_string s =
+  let default = String.sub s 1 (String.length s - 1) in
+  match Re.exec_opt (Re.compile (md_url_regexp ~extract:true)) s with
+  | Some grp -> Option.value (Re.Group.get_opt grp 1) ~default
+  | None -> default
+
+let pp ~with_link ppf u =
+  if with_link then Fmt.pf ppf "[@%s](https://github.com/%s)" u u
+  else Fmt.pf ppf "%s" u

--- a/lib/user.mli
+++ b/lib/user.mli
@@ -1,0 +1,5 @@
+type t = string
+
+val of_string : string -> t
+val regexp : Re.t
+val pp : with_link:bool -> t Fmt.t

--- a/test/cram/cat/aggr.t
+++ b/test/cram/cat/aggr.t
@@ -53,20 +53,20 @@ Engineer reports are aggregated correctly
   # Last Week
   
   - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1.5 days)
     - Some work
     - Some work
   
   - A new KR (New KR)
-    - @eng1 (1 day)
+    - [@eng1](https://github.com/eng1) (1 day)
     - Some work
   
   - A new KR, but different title (New KR)
-    - @eng2 (1 day)
+    - [@eng2](https://github.com/eng2) (1 day)
     - Some work
   
   - Work without a KR (No KR)
-    - @eng1 (1.5 days), @eng2 (1 day)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1 day)
     - Little bit of work
     - Some item of work
     - Small bit of work
@@ -91,7 +91,7 @@ The output of cat passes the lint
   # Last week
   
   - My task (No KR)
-    - @foobar (5 days)
+    - [@foobar](https://github.com/foobar) (5 days)
     - aaa bbb ccc ddd eee fff ggg hhhh iiiii jjj kkk llll mmmm nnnn
       _oooo_ pppp qqqq rrrr sssss tttt uuuu vvvv xxxxxxxx yyyyy zzzzzzzz
       __aaaa__ bbb ccc ddd eee fff ggg hhhh iiiii jjj kkk llll mmmm nnnn

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -34,7 +34,7 @@ When `--okr-db` is passed, metadata is fixed.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 It is possible to filter on category.
@@ -58,7 +58,7 @@ It is possible to filter on category.
   ## Actual objective
   
   - Actual title 2 (Kr2)
-    - @b (1 day)
+    - [@b](https://github.com/b) (1 day)
     - Did more of the things
 
 It is possible to filter by report.
@@ -86,7 +86,7 @@ It is possible to filter by report.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 It is possible to filter by team.
@@ -114,7 +114,7 @@ It is possible to filter by team.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 It is possible to filter on more than one team.
@@ -142,11 +142,11 @@ It is possible to filter on more than one team.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
   
   - Dropped KR (KR3)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did more of the things
 
 Instead of a KR ID, it is possible to put "New KR".
@@ -175,7 +175,7 @@ In that case, metadata is preserved.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
   
   # Another project
@@ -183,7 +183,7 @@ In that case, metadata is preserved.
   ## Another objective
   
   - Something else (New KR)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 If KR ID is "New KR", look for title in database to get real KR ID.
@@ -203,7 +203,7 @@ If KR ID is "New KR", look for title in database to get real KR ID.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 If KR ID is "No KR", look for title in database to get real KR ID.
@@ -226,7 +226,7 @@ If KR ID is "No KR", look for title in database to get real KR ID.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 If WI ID is "No WI", look for title in database to get real WI ID.
@@ -249,7 +249,7 @@ If WI ID is "No WI", look for title in database to get real WI ID.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
 
 Use same case for KR ID as in database.
@@ -273,11 +273,11 @@ Use same case for KR ID as in database.
   ## Actual objective
   
   - Actual title (KR1)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
   
   - Actual title 2 (Kr2)
-    - @b (1 day)
+    - [@b](https://github.com/b) (1 day)
     - Did more of the things
 
 Warn when using KRs that are not active or missing status
@@ -307,13 +307,13 @@ Warn when using KRs that are not active or missing status
   ## Actual objective
   
   - Dropped KR (KR3)
-    - @a (1 day)
+    - [@a](https://github.com/a) (1 day)
     - Did all the things
   
   - Unscheduled KR (KR4)
-    - @b (1 day)
+    - [@b](https://github.com/b) (1 day)
     - Did more of the things
   
   - Missing status KR (KR5)
-    - @b (1 day)
+    - [@b](https://github.com/b) (1 day)
     - Did more of the things

--- a/test/cram/cat/merge.t
+++ b/test/cram/cat/merge.t
@@ -46,7 +46,7 @@ Behaviour without a database
   # Last Week
   
   - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1.5 days)
     - Some work
     - Some other work
 
@@ -54,13 +54,13 @@ Behaviour without a database
   # Last Week
   
   - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days), @eng3 (1.5 days)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1.5 days), [@eng3](https://github.com/eng3) (1.5 days)
     - Some work
     - Some other work
     - Some other, other work
   
   - A Different Kr (KR124)
-    - @eng3 (1.5 days)
+    - [@eng3](https://github.com/eng3) (1.5 days)
     - Some work
 
 Behaviour with a database
@@ -77,7 +77,7 @@ Behaviour with a database
   ## Actual objective
   
   - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1.5 days)
     - Some work
     - Some other work
 
@@ -93,11 +93,11 @@ Behaviour with a database
   ## Actual objective
   
   - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days), @eng3 (1.5 days)
+    - [@eng1](https://github.com/eng1) (1.5 days), [@eng2](https://github.com/eng2) (1.5 days), [@eng3](https://github.com/eng3) (1.5 days)
     - Some work
     - Some other work
     - Some other, other work
   
   - A Different Kr (KR124)
-    - @eng3 (1.5 days)
+    - [@eng3](https://github.com/eng3) (1.5 days)
     - Some work

--- a/test/cram/team-aggregate.t/run.t
+++ b/test/cram/team-aggregate.t/run.t
@@ -5,16 +5,16 @@ Team aggregate example
   # Last Week
   
   - A KR (KR100)
-    - @eng1 (1 day)
+    - [@eng1](https://github.com/eng1) (1 day)
     - Work 1
   
   - A KR (KR123)
-    - @eng1 (1 day), @eng2 (1 day)
+    - [@eng1](https://github.com/eng1) (1 day), [@eng2](https://github.com/eng2) (1 day)
     - Work 1
     - Work 1
   
   - A KR (KR124)
-    - @eng2 (1 day)
+    - [@eng2](https://github.com/eng2) (1 day)
     - Work 1
 
 Only select a few okrs
@@ -23,12 +23,12 @@ Only select a few okrs
   # Last Week
   
   - A KR (KR123)
-    - @eng1 (1 day), @eng2 (1 day)
+    - [@eng1](https://github.com/eng1) (1 day), [@eng2](https://github.com/eng2) (1 day)
     - Work 1
     - Work 1
   
   - A KR (KR124)
-    - @eng2 (1 day)
+    - [@eng2](https://github.com/eng2) (1 day)
     - Work 1
 
 Exclude a few okrs
@@ -37,7 +37,7 @@ Exclude a few okrs
   # Last Week
   
   - A KR (KR100)
-    - @eng1 (1 day)
+    - [@eng1](https://github.com/eng1) (1 day)
     - Work 1
 
 Multiple weeks
@@ -46,18 +46,18 @@ Multiple weeks
   # Last Week
   
   - A KR (KR100)
-    - @eng1 (2 days)
+    - [@eng1](https://github.com/eng1) (2 days)
     - Work 1
     - Work 1
   
   - A KR (KR123)
-    - @eng1 (2 days), @eng2 (2 days)
+    - [@eng1](https://github.com/eng1) (2 days), [@eng2](https://github.com/eng2) (2 days)
     - Work 1
     - Work 1
     - Work 1
     - Work 1
   
   - A KR (KR124)
-    - @eng2 (2 days)
+    - [@eng2](https://github.com/eng2) (2 days)
     - Work 1
     - Work 1

--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -5,7 +5,7 @@
 # Last Week
 
 - Make okra great (OKRA1)
-  - @bactrian (<X> days)
+  - [@bactrian](https://github.com/bactrian) (<X> days)
   - Work Item 1
 
 # Activity (move these items to last week)

--- a/test/pp/aggr.md
+++ b/test/pp/aggr.md
@@ -1,25 +1,25 @@
 # Title
 
 - One KR without objective (New KR)
-  - @engC (1 day)
+  - [@engC](https://github.com/engC) (1 day)
   - Work
 
 ## Project A
 
 - The first KR (KR1)
-  - @engA (4 days)
+  - [@engA](https://github.com/engA) (4 days)
   - Work
   - some Work
 
 ## Project B
 
 - Another KR (KR123)
-  - @engineer1 (4 days), @engineer2 (0.5 days)
+  - [@engineer1](https://github.com/engineer1) (4 days), [@engineer2](https://github.com/engineer2) (0.5 days)
   - A work item
   - A super work item
 
 - Yo (YO1)
-  - @bar (1 day), @foo (2 days), @zorro (0.5 days)
+  - [@bar](https://github.com/bar) (1 day), [@foo](https://github.com/foo) (2 days), [@zorro](https://github.com/zorro) (0.5 days)
   - Hello, world
     hi hoho:
     - one
@@ -45,5 +45,5 @@
 ## Project C
 
 - This is a new KR (New KR)
-  - @engB (2 days)
+  - [@engB](https://github.com/engB) (2 days)
   - Work

--- a/test/pp/eng1.md
+++ b/test/pp/eng1.md
@@ -3,17 +3,17 @@
 ## Project A
 
 - The first KR (KR1)
-  - @engA (2 days)
+  - [@engA](https://github.com/engA) (2 days)
   - Work
 
 ## Project B
 
 - Another KR (KR123)
-  - @engineer1 (1 day), @engineer2 (0.5 days)
+  - [@engineer1](https://github.com/engineer1) (1 day), [@engineer2](https://github.com/engineer2) (0.5 days)
   - A work item
 
 - Yo (YO1)
-  - @bar (1 day), @foo (2 days), @zorro (0.5 days)
+  - [@bar](https://github.com/bar) (1 day), [@foo](https://github.com/foo) (2 days), [@zorro](https://github.com/zorro) (0.5 days)
   - Hello, world
     hi hoho:
     - one
@@ -39,5 +39,5 @@
 ## Project C
 
 - This is a new KR (New KR)
-  - @engB (2 days)
+  - [@engB](https://github.com/engB) (2 days)
   - Work

--- a/test/pp/use_db_replaced.md
+++ b/test/pp/use_db_replaced.md
@@ -3,6 +3,6 @@
 ## Objective A
 
 - Title A (KR123)
-  - @engineer1 (1 day)
+  - [@engineer1](https://github.com/engineer1) (1 day)
   - work 1
   - work 2


### PR DESCRIPTION
Follow-up on #207 and #193, making the usernames clickable in reports produced by `okra generate`, `okra cat` and `okra team aggregate`.

/cc @sabine @jmid @rikusilvola @samoht 