### PR TITLE
Lookup okr-db in the repo directory if okr-db is not set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Changes
 
-- Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#<PR_NUMBER>, @gpetiot)
+- Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#210, @gpetiot)
 - Make github handles clickable in repo reports (#193, #207, @gpetiot)
 - Parser collects all issues instead of raising an exception (#195, @gpetiot).
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Changes
 
+- Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#<PR_NUMBER>, @gpetiot)
 - Make github handles clickable in repo reports (#193, #207, @gpetiot)
 - Parser collects all issues instead of raising an exception (#195, @gpetiot).
   Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -378,7 +378,17 @@ let okr_db t =
   | Some s -> Some s
   | None -> (
       let db =
-        match t.okr_db with Some db -> Some db | None -> Conf.okr_db t.conf
+        let ( or ) x y = match x with Some x -> Some x | None -> y in
+        t.okr_db
+        or Conf.okr_db t.conf
+        or
+        match t.repo with
+        | Some repo -> (
+            let path = Fpath.(v repo / "data" / "db.csv") in
+            match Bos.OS.File.exists path with
+            | Ok true -> Some Fpath.(to_string path)
+            | _ -> None)
+        | None -> None
       in
       match db with
       | None -> None

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -386,7 +386,7 @@ let okr_db t =
         | Some repo -> (
             let path = Fpath.(v repo / "data" / "db.csv") in
             match Bos.OS.File.exists path with
-            | Ok true -> Some Fpath.(to_string path)
+            | Ok true -> Some (Fpath.to_string path)
             | _ -> None)
         | None -> None
       in

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -32,8 +32,8 @@ val okr_db : t -> string option
 (** [okr_db] is the location of the OKR database. *)
 
 val admin_dir : t -> string option
-(** [admin_dir] is the location of the admin directory for the teams
-    subcommands. *)
+(** [admin_dir] is the location of the admin directory.
+    If [okr_db] is not set, the OKR database is lookup up in [admin_dir]. *)
 
 val gitlab_token : t -> string option
 (** [gitlab_token] is the optional Gitlab token, if present your Gitlab activity

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -32,8 +32,7 @@ val okr_db : t -> string option
 (** [okr_db] is the location of the OKR database. *)
 
 val admin_dir : t -> string option
-(** [admin_dir] is the location of the admin directory.
-    If [okr_db] is not set, the OKR database is lookup up in [admin_dir]. *)
+(** [admin_dir] is the location of the admin directory. *)
 
 val gitlab_token : t -> string option
 (** [gitlab_token] is the optional Gitlab token, if present your Gitlab activity

--- a/test/cram/lint/db.t
+++ b/test/cram/lint/db.t
@@ -1,0 +1,62 @@
+Workitems can be checked when a DB of this form is provided:
+
+  $ mkdir -p admin/data
+
+  $ cat > admin/data/db.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "Absence","Leave","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Learn","Learning","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Onboard","Onboard","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Meet","Meet","Active 🏗","Rolling","Engineering","All","","","",""
+  > "#1053","Multicore OCaml Merlin project","Dropped ❌","Q3 2023 - Jul - Sep","Benchmark tooling","","Maintenance - Irmin","","",""
+  > "#1058","Application and Operational Metrics","Complete ✅","Q4 2023 - Oct - Dec","Ci & Ops","QA","Operational Metrics for Core OCaml Services","Jane Street - Community","pillar/qa","50."
+  > "#1090","Property-Based Testing for Multicore","Active 🏗","Q1 2024 - Jan - Mar","Compiler and language","Compiler","Property-Based Testing for Multicore","","pillar/compiler,team/compiler&language,Proposal","25."
+  > "#1115","General okra maintenance","Draft","","","","Maintenance - internal tooling","","pillar/ecosystem,team/internal-tooling",""
+  > EOF
+
+  $ cat > weekly.md << EOF
+  > # Last week
+  > 
+  > - Multicore OCaml Merlin project (#1053)
+  >   - @eng1 (1 day)
+  >   - Some merlin
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (1 day)
+  >   - Some multicore
+  > 
+  > - Invalid name (#1090)
+  >   - @eng1 (1 day)
+  >   - Some metrics
+  > 
+  > - General okra maintenance (#1115)
+  >   - @eng1 (1 day)
+  >   - Some okra
+  > EOF
+
+No check on WIs without the DB:
+
+  $ okra lint -e weekly.md
+  okra: [WARNING] Conflicting titles:
+  - "Property-Based Testing for Multicore"
+  - "Invalid name"
+  [OK]: weekly.md
+
+The DB can be passed through the [--okr-db] option:
+
+  $ okra lint -e --okr-db admin/data/db.csv weekly.md
+  okra: [WARNING] Work logged on KR marked as "Dropped": "Multicore OCaml Merlin project" ("#1053")
+  okra: [WARNING] Conflicting titles:
+  - "Invalid name"
+  - "Property-Based Testing for Multicore"
+  okra: [WARNING] Work logged on KR marked as "Draft": "General okra maintenance" ("#1115")
+  [OK]: weekly.md
+
+The DB can be looked up in the [repo-dir] passed through the [-C]/[--repo-dir] option:
+  $ okra lint -e -C admin weekly.md
+  okra: [WARNING] Work logged on KR marked as "Dropped": "Multicore OCaml Merlin project" ("#1053")
+  okra: [WARNING] Conflicting titles:
+  - "Invalid name"
+  - "Property-Based Testing for Multicore"
+  okra: [WARNING] Work logged on KR marked as "Draft": "General okra maintenance" ("#1115")
+  [OK]: weekly.md


### PR DESCRIPTION
It is not user-friendly to manually specify the location of the database to check, especially when for 99% of users this file is located in their admin repository (`--repo-dir`/`-C`).

/cc @shindere I think you asked for this feature

---
### Next step
This will make the next step much smoother: the switch from workitems to objectives.

We can imagine asking users to specify `--okr-db` and `--obj-db`, but it sounds much better to automatically fetch them with just `-C`.
We will be able to check both `team-objectives.csv` and `db.csv` (same directory) and detect whether workitems are still used and print a warning to point towards the parent objective in `team-objectives.csv`.

/cc @kc @samoht @balat