### PR TITLE
Report work on objectives instead of workitems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Changed
 
+- Lint: activity is now checked against objectives instead of workitems (#218, @gpetiot)
+- Cat/Aggregate: generated reports use objectives instead of workitems (#218, @gpetiot)
 - Use standardized categories for reporting non-engineering work time: Community, Hack, Learning, Leave, Management, Meet and Onboard (#230, @gpetiot)
 - Lint: check the quarter of workitems instead of their status (#228, @gpetiot)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ To generate your last week report:
 okra gen
 ```
 
+To update your report by rewriting workitems into objectives:
+```sh
+okra cat -C /path/to/admin -e old_weekly.md -o new_weekly.md
+```
+
 To lint your report:
 ```sh
 okra lint -e -C /path/to/admin/ report.md

--- a/bin/cat.ml
+++ b/bin/cat.ml
@@ -47,12 +47,12 @@ let run conf =
     | None -> None
     | Some file ->
         let content = read_file file in
-        let exisiting =
+        let exisiting, _warnings =
           Okra.Report.of_markdown ?okr_db (Omd.of_string content)
         in
         Some exisiting
   in
-  let okrs =
+  let okrs, _warnings =
     try
       Okra.Report.of_markdown ?existing_report
         ~ignore_sections:(Common.ignore_sections conf.c)

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -25,7 +25,7 @@ let config_dir =
   let ( / ) = Filename.concat in
   Xdg.config_dir xdg / "okra"
 
-let default_project = { Activity.title = "TODO ADD KR (ID)"; items = [] }
+let default_project = { Activity.title = "OBJECTIVE (ID)"; items = [] }
 
 type project = Activity.project = {
   title : string;
@@ -45,7 +45,8 @@ type t = {
   projects : project list; [@default [ default_project ]]
   teams : Team.t list; [@default []]
   footer : string option;
-  okr_db : string option;
+  work_item_db : string option;
+  objective_db : string option;
   admin_dir : string option;
   gitlab_token : string option;
   work_days_in_a_week : float option;
@@ -57,7 +58,8 @@ let default =
     projects = [ default_project ];
     teams = [];
     footer = None;
-    okr_db = None;
+    work_item_db = None;
+    objective_db = None;
     admin_dir = None;
     gitlab_token = None;
     work_days_in_a_week = None;
@@ -77,7 +79,8 @@ let teams { teams; _ } =
 
 let projects { projects; _ } = projects
 let footer { footer; _ } = footer
-let okr_db t = t.okr_db
+let work_item_db t = t.work_item_db
+let objective_db t = t.objective_db
 let admin_dir t = t.admin_dir
 let gitlab_token t = t.gitlab_token
 let work_days_in_a_week t = t.work_days_in_a_week

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -28,8 +28,11 @@ val projects : t -> Okra.Activity.project list
 val footer : t -> string option
 (** An optional footer to append to the end of your engineer reports *)
 
-val okr_db : t -> string option
-(** [okr_db] is the location of the OKR database. *)
+val work_item_db : t -> string option
+(** [work_item_db] is the location of the work item database. *)
+
+val objective_db : t -> string option
+(** [objective_db] is the location of the objective database. *)
 
 val admin_dir : t -> string option
 (** [admin_dir] is the location of the admin directory. *)

--- a/bin/stats.ml
+++ b/bin/stats.ml
@@ -92,7 +92,7 @@ let print conf t =
         krs
 
 let run conf =
-  let okrs =
+  let okrs, _warnings =
     Okra.Report.of_markdown
       ~ignore_sections:(Common.ignore_sections conf.c)
       ~include_sections:(Common.include_sections conf.c)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Table of contents
   - [Generating a report](engineers-manual.md#generating-a-report)
     - [Configuration](engineers-manual.md#configuration)
   - [Linting your weekly report](engineers-manual.md#linting-your-weekly-report)
+  - [Rewriting your workitems into objectives with okra cat](#rewriting-your-workitems-into-objectives-with-okra-cat)
 - [Team Lead's Manual](team-leads-manual.md)
   - [Aggregating reports](team-leads-manual.md#aggregating-reports)
     - [Aggregating engineer reports](team-leads-manual.md#aggregating-engineer-reports)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Table of contents
   - [Generating a report](engineers-manual.md#generating-a-report)
     - [Configuration](engineers-manual.md#configuration)
   - [Linting your weekly report](engineers-manual.md#linting-your-weekly-report)
-  - [Rewriting your workitems into objectives with okra cat](#rewriting-your-workitems-into-objectives-with-okra-cat)
+  - [Rewriting workitems into objectives](#rewriting-workitems-into-objectives)
 - [Team Lead's Manual](team-leads-manual.md)
   - [Aggregating reports](team-leads-manual.md#aggregating-reports)
     - [Aggregating engineer reports](team-leads-manual.md#aggregating-engineer-reports)

--- a/docs/engineers-manual.md
+++ b/docs/engineers-manual.md
@@ -4,6 +4,7 @@ Table of contents
 - [Generating a report](#generating-a-report)
   - [Configuration](#configuration)
 - [Linting your weekly report](#linting-your-weekly-report)
+- [Rewriting your workitems into objectives with okra cat](#rewriting-your-workitems-into-objectives-with-okra-cat)
 
 ## Generating a report
 
@@ -69,3 +70,52 @@ okra lint --engineer -C /path/to/admin/ report.md
 Do not forget the `--engineer` (or `-e` for short) flag, otherwise your report will be considered as a team report and it will return errors (mostly because `okra` will then check every section of your report).
 
 The expected format of engineer reports is presented [here](report-formats.md#engineer-report)
+
+## Rewriting your workitems into objectives with okra cat
+
+Let's suppose you have the following weekly report:
+
+```md
+# Last Week
+
+- Workitem you have been using (#1090)
+  - @jack (3 days)
+  - Some work you did
+
+- Leave
+  - @eng1 (2 days)
+```
+
+Linting of the original file fails because we used workitems:
+
+```sh
+$ okra lint -C admin -e old_weekly.md
+[ERROR(S)]: old_weekly.md
+  
+Invalid objective:
+  "Workitem you have been using" is a work-item, you should use its parent objective "Objective you should use now" instead
+[1]
+```
+
+We use `okra cat` to automatically rewrite the report using the objectives:
+
+```sh
+$ okra cat -C /path/to/admin -e old_weekly.md -o new_weekly.md
+```
+```md
+# Last Week
+  
+- Property-Based Testing for Multicore (#558)
+  - @eng1 (3 days)
+  - This is a workitem with a parent objective in the DB
+  
+- Leave
+  - @eng1 (2 days)
+```
+
+Linting of the produced file succeeds because we now use objectives:
+
+```sh
+$ okra lint -C admin -e new_weekly.md
+[OK]: new_weekly.md
+```

--- a/docs/engineers-manual.md
+++ b/docs/engineers-manual.md
@@ -105,9 +105,9 @@ $ okra cat -C /path/to/admin -e old_weekly.md -o new_weekly.md
 ```md
 # Last Week
   
-- Property-Based Testing for Multicore (#558)
+- Objective you should use now (#558)
   - @jack (3 days)
-  - This is a workitem with a parent objective in the DB
+  - Some work you did
   
 - Leave
   - @jack (2 days)

--- a/docs/engineers-manual.md
+++ b/docs/engineers-manual.md
@@ -20,7 +20,7 @@ The output looks like this:
 
 - Improve OKRA (#123)
   - @MagnusS (<X> days)
-  - Work Item 1
+  - Some work
 
 # Activity (move these items to last week)
 
@@ -28,7 +28,7 @@ The output looks like this:
   - Add support for including only specified KR IDs [#5](https://github.com/MagnusS/okra/issues/5)
 ```
 
-To prepare the final report, the work items under `Activity` should be moved to `Last week` under the right workitem and time should be added (`<X>` should be replaced with a multiple of `0.5`). Additional context can also be added here.
+To prepare the final report, the work items under `Activity` should be moved to `Last week` under the right objective and time should be added (`<X>` should be replaced with a multiple of `0.5`). Additional context can also be added here.
 
 ```md
 # Last Week

--- a/docs/engineers-manual.md
+++ b/docs/engineers-manual.md
@@ -83,7 +83,7 @@ Let's suppose you have the following weekly report:
   - Some work you did
 
 - Leave
-  - @eng1 (2 days)
+  - @jack (2 days)
 ```
 
 Linting of the original file fails because we used workitems:
@@ -106,11 +106,11 @@ $ okra cat -C /path/to/admin -e old_weekly.md -o new_weekly.md
 # Last Week
   
 - Property-Based Testing for Multicore (#558)
-  - @eng1 (3 days)
+  - @jack (3 days)
   - This is a workitem with a parent objective in the DB
   
 - Leave
-  - @eng1 (2 days)
+  - @jack (2 days)
 ```
 
 Linting of the produced file succeeds because we now use objectives:

--- a/docs/engineers-manual.md
+++ b/docs/engineers-manual.md
@@ -4,7 +4,7 @@ Table of contents
 - [Generating a report](#generating-a-report)
   - [Configuration](#configuration)
 - [Linting your weekly report](#linting-your-weekly-report)
-- [Rewriting your workitems into objectives with okra cat](#rewriting-your-workitems-into-objectives-with-okra-cat)
+- [Rewriting workitems into objectives](#rewriting-workitems-into-objectives)
 
 ## Generating a report
 
@@ -71,7 +71,7 @@ Do not forget the `--engineer` (or `-e` for short) flag, otherwise your report w
 
 The expected format of engineer reports is presented [here](report-formats.md#engineer-report)
 
-## Rewriting your workitems into objectives with okra cat
+## Rewriting workitems into objectives
 
 Let's suppose you have the following weekly report:
 

--- a/docs/report-formats.md
+++ b/docs/report-formats.md
@@ -17,22 +17,22 @@ Engineer reports should be in the following format. Only a section called `Last 
 ```
 # Last week
 
-- My workitem (#123)
+- My objective (#123)
   - @engineer1 (1 day)
-  - Work item 1
+  - Some work
 
 # Notes
 ...
 ```
 
 There are a few rules:
-- Each workitem needs an ID (you can refer to the workitem database, or use "New ID" or "No ID" if you don't know the ID)
+- Each objective needs an ID (you can refer to the objective database, or use "New ID" or "No ID" if you don't know the ID)
 - The total time reported must be 5 days (time off or partial work time must be reported)
 - The time must be reported in multiples of 0.5 days
 
 ### Non-engineering work time
 
-Special workitems can be used to report the following activities:
+Special objectives can be used to report the following activities:
 - `Community`: Maintenance work that does not fall into any maintenance proposals. Discussion on discuss, discord, slack.
 - `Hack`: Hacking Days
 - `Learning`: Attending company-sponsored training, attending Conferences, learning, Mirage/OCaml retreats
@@ -67,20 +67,20 @@ By default the repository report does not contain author names, time of creation
 
 ## Team activity report
 
-The expected team report format is similar, but here every section is parsed and multiple engineers may have worked on each workitem.
+The expected team report format is similar, but here every section is parsed and multiple engineers may have worked on each objective.
 
-```
+```md
 # Project
 
 ## Objective
 
-- My workitem (#123)
+- My objective (#123)
   - @engineer1 (1 day), @engineer2 (2 days)
-  - work item 1
+  - item 1
     - subitem
-  - work item 2
+  - item 2
 ```
 
-If the workitem hasn't been created yet, "new KR" is recognised by the parser as a placeholder and can be used instead. If a workitem of the same name is found in the database, they will be combined.
+If the objective hasn't been created yet, "new KR" is recognised by the parser as a placeholder and can be used instead. If an objective of the same name is found in the database, they will be combined.
 
-The `okra cat` command can be used to aggregate multiple engineer reports into one team report grouped by workitem.
+The `okra cat` command can be used to aggregate multiple engineer reports into one team report grouped by objective.

--- a/docs/team-leads-manual.md
+++ b/docs/team-leads-manual.md
@@ -12,7 +12,7 @@ Table of contents
 
 ### Aggregating engineer reports
 
-`okra cat` can be used to aggregate weekly engineer or team reports in a single report. The tool will attempt to group data by project, objective and KR if these match.
+`okra cat` can be used to aggregate weekly engineer or team reports in a single report. The tool will attempt to group data by project and objective if these match.
 
 The code reads data from stdin, aggregates per KR and outputs the result.
 
@@ -47,7 +47,7 @@ $ cat report.md report2.md | okra cat --engineer --show-time-calc=true
     ...
 ```
 
-Several other options are available for modifying the output format, see `okra cat --help` for details. For example, only specific KRs can be included with `--include-krs=123`. Time can optionally be removed with `--show-time=false`. Sections can be ignored and removed from the final output using `--ignore-sections`.
+Several other options are available for modifying the output format, see `okra cat --help` for details. For example, only specific objectives can be included with `--include-krs=123`. Time can optionally be removed with `--show-time=false`. Sections can be ignored and removed from the final output using `--ignore-sections`.
 
 ### Aggregating team reports
 

--- a/docs/vim-integration.md
+++ b/docs/vim-integration.md
@@ -27,7 +27,7 @@ autocmd BufRead,BufNewFile ~/src/weekly-reports/* let g:syntastic_markdown_check
 
 ## Workitem name completion
 
-While not strictly related to `okra` it can be handy to complete workitem names from a
+While not strictly related to `okra` it can be handy to complete objective names from a
 fixed list.
 
 To do so it is possible to rely on the `fzf.vim` plugin:
@@ -37,14 +37,14 @@ To do so it is possible to rely on the `fzf.vim` plugin:
 Plug 'junegunn/fzf.vim'
 
 " Later
-inoremap <expr> <c-x><c-k> fzf#vim#complete('cat /path/to/.okrs')
+inoremap <expr> <c-x><c-k> fzf#vim#complete('cat /path/to/.objectives')
 ```
 
-And create a file at `/path/to/.okrs` with one line per workitem, for example:
+And create a file at `/path/to/.objectives` with one line per objective, for example:
 
 ```
-- libsomething supports Windows (Some1)
-- program P is integrated with dune (P12)
+- libsomething supports Windows (#101)
+- program P is integrated with dune (#102)
 ```
 
 Now when in insert mode, <kbd>Ctrl</kbd>+<kbd>X</kbd> followed by

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -442,11 +442,3 @@ let items ?(show_time = true) ?(show_time_calc = false) ?(show_engineers = true)
           ];
         ] );
   ]
-
-module Unsafe = struct
-  let to_work x =
-    match x.kind with
-    | Work w -> w
-    | Meta m ->
-        Fmt.invalid_arg "Unsafe.to_work %a: expected a Work Item" Meta.pp m
-end

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -362,13 +362,13 @@ type warning =
   | Objective_not_found of Work.t
   | Migration of { work_item : Work.t; objective : Work.t option }
 
-let update_from_master_db orig_kr (db : Masterdb.t) =
+let update_from_master_db orig_kr db =
   match orig_kr.kind with
   | Meta _ -> (orig_kr, None)
   | Work orig_work -> (
       let db_kr =
         match orig_work.id with
-        | ID id -> Masterdb.Objective.find_kr_opt db.objective_db id
+        | ID id -> Masterdb.Objective.find_kr_opt db.Masterdb.objective_db id
         | _ -> Masterdb.Objective.find_title_opt db.objective_db orig_work.title
       in
       match db_kr with

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -397,9 +397,9 @@ let update_from_master_db orig_kr db =
                   (* Not found in objectives, found in WI db, has objective *)
                   | Some { printable_id = id; title; quarter; _ } ->
                       let work = { Work.id = ID id; title; quarter } in
-                      let objective = Some work in
                       let kr = { orig_kr with kind = Work work } in
-                      (kr, Some (Migration { work_item; objective })))))
+                      (kr, Some (Migration { work_item; objective = Some work }))
+                  )))
       | Some db_kr ->
           if orig_work.id = No_KR then
             Log.warn (fun l ->

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -95,13 +95,6 @@ val merge : t -> t -> t
 val compare : t -> t -> int
 val update_from_master_db : t -> Masterdb.t -> t * warning option
 
-(** Functions in this module can raise exceptions.
-    Use at your own risk. *)
-module Unsafe : sig
-  val to_work : t -> Work.t
-  (** @raise Invalid_argument if the argument kind is of type [Meta.t]. *)
-end
-
 (** {2 Pretty-print} *)
 
 val items :

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -87,7 +87,20 @@ val v :
 val dump : t Fmt.t
 val merge : t -> t -> t
 val compare : t -> t -> int
-val update_from_master_db : t -> Masterdb.t -> t
+
+(** Functions in this module can raise exceptions.
+    Use at your own risk. *)
+module Unsafe : sig
+  val to_work : t -> Work.t
+  (** @raise Invalid_argument if the argument kind is of type [Meta.t]. *)
+end
+
+type kr_lookup_error =
+  | Not_found of t
+  | Migrate_work_item of t
+  | Migrate_work_item_to_objective of t * t
+
+val update_from_master_db : t -> Masterdb.t -> (t, kr_lookup_error) result
 
 (** {2 Pretty-print} *)
 

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -101,7 +101,7 @@ type warning =
       (** For retro-compatibility only.
           This case should be removed once everything has migrated to objectives. *)
 
-val update_from_master_db : t -> Masterdb.t -> (t, warning) result
+val update_from_master_db : t -> Masterdb.t -> t * warning option
 
 (** {2 Pretty-print} *)
 

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -95,12 +95,13 @@ module Unsafe : sig
   (** @raise Invalid_argument if the argument kind is of type [Meta.t]. *)
 end
 
-type kr_lookup_error =
-  | Not_found of t
-  | Migrate_work_item of t
-  | Migrate_work_item_to_objective of t * t
+type warning =
+  | Objective_not_found of Work.t
+  | Migration of { work_item : Work.t; objective : Work.t option }
+      (** For retro-compatibility only.
+          This case should be removed once everything has migrated to objectives. *)
 
-val update_from_master_db : t -> Masterdb.t -> (t, kr_lookup_error) result
+val update_from_master_db : t -> Masterdb.t -> (t, warning) result
 
 (** {2 Pretty-print} *)
 

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -76,6 +76,12 @@ module Id : sig
   val compare : t -> t -> int
 end
 
+type warning =
+  | Objective_not_found of Work.t
+  | Migration of { work_item : Work.t; objective : Work.t option }
+      (** For retro-compatibility only.
+          This case should be removed once everything has migrated to objectives. *)
+
 val v :
   kind:Kind.t ->
   project:string ->
@@ -87,6 +93,7 @@ val v :
 val dump : t Fmt.t
 val merge : t -> t -> t
 val compare : t -> t -> int
+val update_from_master_db : t -> Masterdb.t -> t * warning option
 
 (** Functions in this module can raise exceptions.
     Use at your own risk. *)
@@ -94,14 +101,6 @@ module Unsafe : sig
   val to_work : t -> Work.t
   (** @raise Invalid_argument if the argument kind is of type [Meta.t]. *)
 end
-
-type warning =
-  | Objective_not_found of Work.t
-  | Migration of { work_item : Work.t; objective : Work.t option }
-      (** For retro-compatibility only.
-          This case should be removed once everything has migrated to objectives. *)
-
-val update_from_master_db : t -> Masterdb.t -> t * warning option
 
 (** {2 Pretty-print} *)
 

--- a/lib/filter.ml
+++ b/lib/filter.ml
@@ -106,7 +106,7 @@ let apply f (t : Report.t) =
           if
             StringSet.is_empty f.include_engineers
             && StringSet.is_empty f.exclude_engineers
-          then Report.add new_t kr
+          then ignore @@ Report.add new_t kr
           else
             let time_entries =
               List.fold_left
@@ -127,7 +127,8 @@ let apply f (t : Report.t) =
               |> List.rev
             in
             if time_entries = [] then ()
-            else if time_entries = kr.time_entries then Report.add new_t kr
+            else if time_entries = kr.time_entries then
+              ignore @@ Report.add new_t kr
             else
               let work =
                 Item.
@@ -146,7 +147,7 @@ let apply f (t : Report.t) =
                 KR.v ~project:kr.project ~objective:kr.objective ~time_entries
                   ~kind:kr.kind work
               in
-              Report.add new_t kr
+              ignore @@ Report.add new_t kr
         in
         let check x (incl, excl) =
           match StringSet.(is_empty incl, is_empty excl) with

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -29,6 +29,11 @@ type lint_error =
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t
+  | Invalid_objective of KR.t
+  | Invalid_objective_but_work_item of {
+      work_item : KR.t;
+      objective : KR.t option;
+    }
 
 type lint_result = (unit, lint_error list) result
 
@@ -100,6 +105,22 @@ let pp_error ppf = function
   | Invalid_quarter kr ->
       Fmt.pf ppf "@[<hv 2>In WI %S:@ Work logged on WI scheduled for %a@]@,"
         kr.title (Fmt.option Quarter.pp) kr.quarter
+  | Invalid_objective x ->
+      let x = KR.Unsafe.to_work x in
+      Fmt.pf ppf "@[<hv 2>Invalid objective:@ %S@]@," x.title
+  | Invalid_objective_but_work_item { work_item; objective = None } ->
+      let wi = KR.Unsafe.to_work work_item in
+      Fmt.pf ppf
+        "@[<hv 2>Invalid objective:@ %S is a work-item, you should use an \
+         objective instead@]@,"
+        wi.title
+  | Invalid_objective_but_work_item { work_item; objective = Some objective } ->
+      let wi = KR.Unsafe.to_work work_item in
+      let obj = KR.Unsafe.to_work objective in
+      Fmt.pf ppf
+        "@[<hv 2>Invalid objective:@ %S is a work-item, you should use its \
+         parent objective %S instead@]@,"
+        wi.title obj.title
 
 let string_of_error = Fmt.to_to_string pp_error
 
@@ -190,7 +211,22 @@ let check_document ?okr_db ~include_sections ~ignore_sections ?check_time
     | Error w -> w :: warnings
   in
   let* () = maybe_emit warnings in
-  let report = Report.of_krs ?okr_db okrs in
+  let report, report_warnings = Report.of_krs ?okr_db okrs in
+  let warnings =
+    List.fold_left
+      (fun acc w ->
+        match w with
+        | KR.Not_found x -> Invalid_objective x :: acc
+        | Migrate_work_item x ->
+            Invalid_objective_but_work_item { work_item = x; objective = None }
+            :: acc
+        | Migrate_work_item_to_objective (x, y) ->
+            Invalid_objective_but_work_item
+              { work_item = x; objective = Some y }
+            :: acc)
+      warnings report_warnings
+  in
+  let* () = maybe_emit warnings in
   let krs = Report.all_krs report in
   let warnings = check_quarters quarter krs warnings in
   let* () = maybe_emit warnings in
@@ -276,3 +312,19 @@ let short_messages_of_error file_name =
   | Invalid_quarter kr ->
       short_messagef None "Using KR of invalid quarter: %S (%a)" kr.title
         (Fmt.option Quarter.pp) kr.quarter
+  | Invalid_objective x ->
+      let x = KR.Unsafe.to_work x in
+      short_messagef None "Invalid objective: %S" x.title
+  | Invalid_objective_but_work_item { work_item; objective = None } ->
+      let wi = KR.Unsafe.to_work work_item in
+      short_messagef None
+        "Invalid objective:@ %S is a work-item, an objective should be used \
+         instead"
+        wi.title
+  | Invalid_objective_but_work_item { work_item; objective = Some objective } ->
+      let wi = KR.Unsafe.to_work work_item in
+      let obj = KR.Unsafe.to_work objective in
+      short_messagef None
+        "Invalid objective:@ %S is a work-item, its parent objective %S should \
+         be used instead"
+        wi.title obj.title

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -27,11 +27,7 @@ type lint_error =
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t
-  | Invalid_objective of KR.t
-  | Invalid_objective_but_work_item of {
-      work_item : KR.t;
-      objective : KR.t option;
-    }
+  | Invalid_objective of KR.warning
 
 type lint_result = (unit, lint_error list) result
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -27,6 +27,11 @@ type lint_error =
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t
+  | Invalid_objective of KR.t
+  | Invalid_objective_but_work_item of {
+      work_item : KR.t;
+      objective : KR.t option;
+    }
 
 type lint_result = (unit, lint_error list) result
 

--- a/lib/masterdb.mli
+++ b/lib/masterdb.mli
@@ -14,29 +14,44 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type status_t =
-  | Draft
-  | Scheduled
-  | Active
-  | Paused
-  | Blocked
-  | Complete
-  | Dropped
+module Objective : sig
+  type status_t = Todo | In_progress | Paused | Complete | Closed
 
-type elt_t = private {
-  id : string;
-  printable_id : string;
-  title : string;
-  objective : string;
-  team : string;
-  status : status_t option;
-  quarter : Quarter.t option;
-}
+  type elt_t = private {
+    id : string;
+    printable_id : string;
+    title : string;
+    project : string;
+    team : string;
+    status : status_t option;
+    quarter : Quarter.t option;
+  }
 
-type t = (string, elt_t) Hashtbl.t
+  type t = (string, elt_t) Hashtbl.t
 
-val string_of_status : status_t -> string
-val load_csv : ?separator:char -> string -> (t, [ `Msg of string ]) result
-val find_kr_opt : t -> string -> elt_t option
-val find_title_opt : t -> string -> elt_t option
-val find_krs_for_teams : t -> string list -> elt_t list
+  val string_of_status : status_t -> string
+  val load_csv : ?separator:char -> string -> (t, [ `Msg of string ]) result
+  val find_kr_opt : t -> string -> elt_t option
+  val find_title_opt : t -> string -> elt_t option
+  val find_krs_for_teams : t -> string list -> elt_t list
+end
+
+module Work_item : sig
+  type elt_t = private {
+    id : string;
+    printable_id : string;
+    title : string;
+    objective : string;
+    project : string;
+    team : string;
+    status : string;
+    quarter : Quarter.t option;
+  }
+
+  type t = (string, elt_t) Hashtbl.t
+
+  val load_csv : ?separator:char -> string -> (t, [ `Msg of string ]) result
+  val find_title_opt : t -> string -> elt_t option
+end
+
+type t = { objective_db : Objective.t; work_item_db : Work_item.t option }

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -148,11 +148,7 @@ let add ?okr_db (t : t) (e : KR.t) =
     | Some db -> (
         match KR.update_from_master_db e db with
         | Ok x as result -> (result, x)
-        | Error
-            ( Not_found x
-            | Migrate_work_item x
-            | Migrate_work_item_to_objective (_, x) ) as result ->
-            (result, x))
+        | Error _ as result -> (result, e))
   in
   (* lookup an existing KR in the report *)
   let existing_kr =

--- a/lib/report.mli
+++ b/lib/report.mli
@@ -34,7 +34,7 @@ module Objective : sig
 end
 
 val empty : unit -> t
-val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t * KR.kr_lookup_error list
+val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t * KR.warning list
 
 val of_markdown :
   ?existing_report:t ->
@@ -43,7 +43,7 @@ val of_markdown :
   ?okr_db:Masterdb.t ->
   ?report_kind:Parser.report_kind ->
   Parser.markdown ->
-  t * KR.kr_lookup_error list
+  t * KR.warning list
 
 val iter :
   ?project:(string -> project -> unit) ->
@@ -53,7 +53,7 @@ val iter :
   unit
 
 val find : t -> KR.Id.t -> KR.t list
-val add : ?okr_db:Masterdb.t -> t -> KR.t -> (KR.t, KR.kr_lookup_error) result
+val add : ?okr_db:Masterdb.t -> t -> KR.t -> (KR.t, KR.warning) result
 val all_krs : t -> KR.t list
 
 val pp :

--- a/lib/report.mli
+++ b/lib/report.mli
@@ -34,7 +34,7 @@ module Objective : sig
 end
 
 val empty : unit -> t
-val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t
+val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t * KR.kr_lookup_error list
 
 val of_markdown :
   ?existing_report:t ->
@@ -43,7 +43,7 @@ val of_markdown :
   ?okr_db:Masterdb.t ->
   ?report_kind:Parser.report_kind ->
   Parser.markdown ->
-  t
+  t * KR.kr_lookup_error list
 
 val iter :
   ?project:(string -> project -> unit) ->
@@ -53,7 +53,7 @@ val iter :
   unit
 
 val find : t -> KR.Id.t -> KR.t list
-val add : ?okr_db:Masterdb.t -> t -> KR.t -> unit
+val add : ?okr_db:Masterdb.t -> t -> KR.t -> (KR.t, KR.kr_lookup_error) result
 val all_krs : t -> KR.t list
 
 val pp :

--- a/lib/report.mli
+++ b/lib/report.mli
@@ -53,7 +53,7 @@ val iter :
   unit
 
 val find : t -> KR.Id.t -> KR.t list
-val add : ?okr_db:Masterdb.t -> t -> KR.t -> (KR.t, KR.warning) result
+val add : ?okr_db:Masterdb.t -> t -> KR.t -> KR.warning option
 val all_krs : t -> KR.t list
 
 val pp :

--- a/lib/team.ml
+++ b/lib/team.ml
@@ -173,7 +173,7 @@ let aggregate ?okr_db admin_dir ~year ~weeks teams =
          files
   in
   let md = Omd.of_string content in
-  let report =
+  let report, _warnings =
     try Report.of_markdown ~report_kind:Engineer ?okr_db md
     with e ->
       Printf.eprintf

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -1,17 +1,17 @@
 Master DB
 ---------
 
-When `--okr-db` is passed, metadata is fixed.
+When `--objective-db` is passed, metadata is fixed.
 
-  $ cat > okrs.csv << EOF
+  $ cat > team-objectives.csv << EOF
   > id,title,objective,status,team,quarter
-  > KR1,Actual title,Actual objective,active,team1,"Q1 2023 - Jan-Mar"
-  > Kr2,Actual title 2,Actual objective,active,team1,"Q2 2021 - Apr-Jun"
-  > KR3,Dropped KR,Actual objective,dropped,team2,"Q2 2024 - Apr-Jun"
-  > KR5,Missing status KR,Actual objective,,team2,"Rolling"
+  > KR1,Actual title,,In Progress,team1,"Q1 2023 - Jan-Mar"
+  > Kr2,Actual title 2,,In Progress,team1,"Q2 2021 - Apr-Jun"
+  > KR3,Dropped KR,,Closed,team2,"Q2 2024 - Apr-Jun"
+  > KR5,Missing status KR,,,team2,"Rolling"
   > EOF
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Wrong project
   > 
   > ## Wrong objective
@@ -23,12 +23,9 @@ When `--okr-db` is passed, metadata is fixed.
   okra: [WARNING] Conflicting titles:
   - "Wrong title"
   - "Actual title"
-  okra: [WARNING] KR Wrong title (KR1) appears in two objectives:
-  - "Wrong objective"
-  - "Actual objective"
   # Wrong project
   
-  ## Actual objective
+  ## Wrong objective
   
   - Actual title (KR1)
     - @a (1 day)
@@ -36,7 +33,7 @@ When `--okr-db` is passed, metadata is fixed.
 
 It is possible to filter by team.
 
-  $ okra cat --okr-db=okrs.csv --include-teams=team1 << EOF
+  $ okra cat --objective-db=team-objectives.csv --include-teams=team1 << EOF
   > # Project
   > 
   > - Actual title (KR1)
@@ -48,8 +45,6 @@ It is possible to filter by team.
   >   - Did more of the things
   > EOF
   # Project
-  
-  ## Actual objective
   
   - Actual title (KR1)
     - @a (1 day)
@@ -57,7 +52,7 @@ It is possible to filter by team.
 
 It is possible to filter on more than one team.
 
-  $ okra cat --okr-db=okrs.csv --include-teams=team1,team2 << EOF
+  $ okra cat --objective-db=team-objectives.csv --include-teams=team1,team2 << EOF
   > # Project
   > 
   > - Actual title (KR1)
@@ -69,8 +64,6 @@ It is possible to filter on more than one team.
   >   - Did more of the things
   > EOF
   # Project
-  
-  ## Actual objective
   
   - Actual title (KR1)
     - @a (1 day)
@@ -83,7 +76,7 @@ It is possible to filter on more than one team.
 Instead of a KR ID, it is possible to put "New KR".
 In that case, metadata is preserved.
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective
@@ -119,7 +112,7 @@ In that case, metadata is preserved.
 
 If KR ID is "New KR", look for title in database to get real KR ID.
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective
@@ -139,7 +132,7 @@ If KR ID is "New KR", look for title in database to get real KR ID.
 
 If KR ID is "No KR", look for title in database to get real KR ID.
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective
@@ -162,7 +155,7 @@ If KR ID is "No KR", look for title in database to get real KR ID.
 
 If WI ID is "No WI", look for title in database to get real WI ID.
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective
@@ -185,7 +178,7 @@ If WI ID is "No WI", look for title in database to get real WI ID.
 
 Use same case for KR ID as in database.
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective
@@ -213,7 +206,7 @@ Use same case for KR ID as in database.
 
 Warn when using KRs that are not active or missing status
 
-  $ okra cat --okr-db=okrs.csv << EOF
+  $ okra cat --objective-db=team-objectives.csv << EOF
   > # Actual project
   > 
   > ## Actual objective

--- a/test/cram/cat/merge.t
+++ b/test/cram/cat/merge.t
@@ -41,10 +41,10 @@ Engineer reports are aggregated correctly
   >   - @eng3 (2 days)
   > EOF
 
-  $ cat > okrs.csv << EOF
+  $ cat > team-objectives.csv << EOF
   > id,title,objective,status,team,project
-  > KR123,A Kr,Actual objective,active,,Actual project
-  > KR124,A Different Kr,Actual objective,active,,Actual project
+  > KR123,A Kr,,In Progress,,Actual project
+  > KR124,A Different Kr,,In Progress,,Actual project
   > EOF
 
 Behaviour without a database
@@ -78,26 +78,19 @@ Behaviour without a database
 
 Behaviour with a database
 
-  $ cat eng1.md eng2.md | okra cat --okr-db=okrs.csv --engineer > agg.md && cat agg.md
+  $ cat eng1.md eng2.md | okra cat --objective-db=team-objectives.csv --engineer > agg.md && cat agg.md
   # Last Week
-  
-  - Leave
-    - @eng1 (2 days), @eng2 (2 days)
-  
-  ## Actual objective
   
   - A Kr (KR123)
     - @eng1 (1.5 days), @eng2 (1.5 days)
     - Some work
     - Some other work
-
-  $ okra cat --okr-db=okrs.csv --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
-  # Last Week
   
   - Leave
-    - @eng1 (2 days), @eng2 (2 days), @eng3 (2 days)
-  
-  ## Actual objective
+    - @eng1 (2 days), @eng2 (2 days)
+
+  $ okra cat --objective-db=team-objectives.csv --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
+  # Last Week
   
   - A Kr (KR123)
     - @eng1 (1.5 days), @eng2 (1.5 days), @eng3 (1.5 days)
@@ -108,3 +101,6 @@ Behaviour with a database
   - A Different Kr (KR124)
     - @eng3 (1.5 days)
     - Some work
+  
+  - Leave
+    - @eng1 (2 days), @eng2 (2 days), @eng3 (2 days)

--- a/test/cram/cat/migrate.t
+++ b/test/cram/cat/migrate.t
@@ -51,12 +51,11 @@ This weekly is using objectives:
   >   - This is an objective
   > 
   > - Improve OCaml experience on Windows (#677)
-  >   - @eng (1 days)
+  >   - @eng2 (1 day)
   >   - This is an objective
   > 
   > - Leave
   >   - @eng2 (2 days)
-  > 
   > EOF
 
   $ cat eng1.md eng2.md | okra cat -C admin --engineer
@@ -72,7 +71,7 @@ This weekly is using objectives:
     - This is an objective
   
   - Improve OCaml experience on Windows (#677)
-    - @eng (1 day)
+    - @eng2 (1 day)
     - This is an objective
   
   - Leave

--- a/test/cram/cat/migrate.t
+++ b/test/cram/cat/migrate.t
@@ -1,0 +1,79 @@
+We used to report on workitems and now we use objectives.
+
+During the transition, using workitems makes the linting fail
+and the error message points to the corresponding objective.
+
+  $ mkdir -p admin/data
+
+  $ cat > admin/data/db.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "Absence","Leave","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Learn","Learning","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Onboard","Onboard","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Meet","Meet","Active 🏗","Rolling","Engineering","All","","","",""
+  > "#1053","Multicore OCaml Merlin project","Dropped ❌","Q3 2023 - Jul - Sep","Benchmark tooling","","Maintenance - Irmin","","",""
+  > "#1058","Application and Operational Metrics","Complete ✅","Q4 2023 - Oct - Dec","Ci & Ops","QA","Operational Metrics for Core OCaml Services","Jane Street - Community","pillar/qa","50."
+  > "#1090","Property-Based Testing for Multicore","Active 🏗","Q1 2024 - Jan - Mar","Compiler and language","Compiler","Property-Based Testing for Multicore","","pillar/compiler,team/compiler&language,Proposal","25."
+  > "#1115","General okra maintenance","Draft","","","","Maintenance - internal tooling","","pillar/ecosystem,team/internal-tooling",""
+  > EOF
+
+  $ cat > admin/data/team-objectives.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "#558","Property-Based Testing for Multicore","In Progress","Q2 2024","Compiler & Language","Compiler","","","Proposal",""
+  > "#677","Improve OCaml experience on Windows","Todo","Q2 2024","Multicore applications","Ecosystem","","","",""
+  > "#701","JSOO Effect Performance","","Q2 2024","Compiler & Language","Compiler","","","focus/technology,level/team",""
+  > EOF
+
+This weekly is using using workitems:
+
+  $ cat > eng1.md << EOF
+  > # Last Week
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (2 days)
+  >   - This is a workitem with a parent objective in the DB
+  > 
+  > - Application and Operational Metrics (#1058)
+  >   - @eng1 (1 day)
+  >   - This is a workitem with no parent objective in the DB
+  > 
+  > - Leave
+  >   - @eng1 (2 days)
+  > EOF
+
+This weekly is using objectives:
+
+  $ cat > eng2.md << EOF
+  > # Last Week
+  > 
+  > - Property-Based Testing for Multicore (#558)
+  >   - @eng2 (2 days)
+  >   - This is an objective
+  > 
+  > - Improve OCaml experience on Windows (#677)
+  >   - @eng (1 days)
+  >   - This is an objective
+  > 
+  > - Leave
+  >   - @eng2 (2 days)
+  > 
+  > EOF
+
+  $ cat eng1.md eng2.md | okra cat -C admin --engineer
+  # Last Week
+  
+  - Application and Operational Metrics (#1058)
+    - @eng1 (1 day)
+    - This is a workitem with no parent objective in the DB
+  
+  - Property-Based Testing for Multicore (#558)
+    - @eng1 (2 days), @eng2 (2 days)
+    - This is a workitem with a parent objective in the DB
+    - This is an objective
+  
+  - Improve OCaml experience on Windows (#677)
+    - @eng (1 day)
+    - This is an objective
+  
+  - Leave
+    - @eng1 (2 days), @eng2 (2 days)

--- a/test/cram/cat/migrate.t
+++ b/test/cram/cat/migrate.t
@@ -76,3 +76,43 @@ This weekly is using objectives:
   
   - Leave
     - @eng1 (2 days), @eng2 (2 days)
+
+# Automatic update of weekly using okra cat
+
+  $ cat > eng1.workitems.md << EOF
+  > # Last Week
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (3 days)
+  >   - This is a workitem with a parent objective in the DB
+  > 
+  > - Leave
+  >   - @eng1 (2 days)
+  > EOF
+
+Linting of the original file fails because we used workitems
+
+  $ okra lint -e -C admin eng1.workitems.md
+  [ERROR(S)]: eng1.workitems.md
+  
+  Invalid objective:
+    "Property-Based Testing for Multicore" is a work-item, you should use its parent objective "Property-Based Testing for Multicore" instead
+  [1]
+
+We rewrite the file using okra cat
+
+  $ okra cat -e -C admin eng1.workitems.md -o eng1.objectives.md
+  $ cat eng1.objectives.md
+  # Last Week
+  
+  - Property-Based Testing for Multicore (#558)
+    - @eng1 (3 days)
+    - This is a workitem with a parent objective in the DB
+  
+  - Leave
+    - @eng1 (2 days)
+
+Linting of the produced file succeeds because we now use objectives
+
+  $ okra lint -e -C admin eng1.objectives.md
+  [OK]: eng1.objectives.md

--- a/test/cram/lint/db.t
+++ b/test/cram/lint/db.t
@@ -53,11 +53,7 @@ Workitems can be checked when a DB of this form is provided:
   > EOF
 
   $ okra lint -e -C admin admin/weekly/2023/50/eng1.md
-  [ERROR(S)]: admin/weekly/2023/50/eng1.md
-  
-  In WI "Property-Based Testing for Multicore":
-    Work logged on WI scheduled for 2024 Q1
-  [1]
+  [OK]: admin/weekly/2023/50/eng1.md
 
   $ okra lint -e -C admin admin/weekly/2023/50/eng2.md
   [OK]: admin/weekly/2023/50/eng2.md
@@ -65,11 +61,7 @@ Workitems can be checked when a DB of this form is provided:
   $ cp admin/weekly/2023/50/eng1.md admin/weekly/2024/01/eng1.md
 
   $ okra lint -e -C admin admin/weekly/2024/01/eng1.md
-  [ERROR(S)]: admin/weekly/2024/01/eng1.md
-  
-  In WI "Application and Operational Metrics":
-    Work logged on WI scheduled for 2023 Q4
-  [1]
+  [OK]: admin/weekly/2024/01/eng1.md
 
   $ cat > weekly.md << EOF
   > # Last week
@@ -101,15 +93,15 @@ No check on WIs without the DB:
 
 The DB can be passed through the [--okr-db] option:
 
-  $ okra lint -e --okr-db admin/data/db.csv weekly.md
+  $ okra lint -e --work-item-db admin/data/db.csv weekly.md
   okra: [WARNING] Conflicting titles:
-  - "Invalid name"
   - "Property-Based Testing for Multicore"
+  - "Invalid name"
   [OK]: weekly.md
 
 The DB can be looked up in the [repo-dir] passed through the [-C]/[--repo-dir] option:
   $ okra lint -e -C admin weekly.md
   okra: [WARNING] Conflicting titles:
-  - "Invalid name"
   - "Property-Based Testing for Multicore"
+  - "Invalid name"
   [OK]: weekly.md

--- a/test/cram/lint/migrate.t
+++ b/test/cram/lint/migrate.t
@@ -1,0 +1,63 @@
+We used to report on workitems and now we use objectives.
+
+During the transition, using workitems makes the linting fail
+and the error message points to the corresponding objective.
+
+  $ mkdir -p admin/data
+
+  $ cat > admin/data/db.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "Absence","Leave","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Learn","Learning","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Onboard","Onboard","Active 🏗","Rolling","Engineering","All","","","",""
+  > "Meet","Meet","Active 🏗","Rolling","Engineering","All","","","",""
+  > "#1053","Multicore OCaml Merlin project","Dropped ❌","Q3 2023 - Jul - Sep","Benchmark tooling","","Maintenance - Irmin","","",""
+  > "#1058","Application and Operational Metrics","Complete ✅","Q4 2023 - Oct - Dec","Ci & Ops","QA","Operational Metrics for Core OCaml Services","Jane Street - Community","pillar/qa","50."
+  > "#1090","Property-Based Testing for Multicore","Active 🏗","Q1 2024 - Jan - Mar","Compiler and language","Compiler","Property-Based Testing for Multicore","","pillar/compiler,team/compiler&language,Proposal","25."
+  > "#1115","General okra maintenance","Draft","","","","Maintenance - internal tooling","","pillar/ecosystem,team/internal-tooling",""
+  > EOF
+
+  $ cat > admin/data/team-objectives.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "#558","Property-Based Testing for Multicore","In Progress","Q2 2024","Compiler & Language","Compiler","","","Proposal",""
+  > "#677","Improve OCaml experience on Windows","Todo","Q2 2024","Multicore applications","Ecosystem","","","",""
+  > "#701","JSOO Effect Performance","","Q2 2024","Compiler & Language","Compiler","","","focus/technology,level/team",""
+  > EOF
+
+  $ cat > weekly.md << EOF
+  > # Last week
+  > 
+  > - JSOO Effect Performance (No KR)
+  >   - @eng1 (1 day)
+  >   - xxx
+  > 
+  > - Improve OCaml experience on Windows (#677)
+  >   - @eng1 (1 day)
+  >   - xxx
+  > 
+  > - Property-Based Testing for Multicore (#558)
+  >   - @eng1 (1 day)
+  >   - xxx
+  > 
+  > - General okra maintenance (#1115)
+  >   - @eng1 (1 day)
+  >   - xxx
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (1 day)
+  >   - xxx
+  > EOF
+
+  $ okra lint -e -C admin weekly.md
+  okra: [WARNING] KR ID updated from "No KR" to "#701":
+  - "JSOO Effect Performance"
+  - "JSOO Effect Performance"
+  [ERROR(S)]: weekly.md
+  
+  Invalid objective:
+    "General okra maintenance" is a work-item, you should use an objective instead
+  [ERROR(S)]: weekly.md
+  
+  Invalid objective:
+    "Property-Based Testing for Multicore" is a work-item, you should use its parent objective "Property-Based Testing for Multicore" instead
+  [1]

--- a/test/cram/team-aggregate.t/run.t
+++ b/test/cram/team-aggregate.t/run.t
@@ -127,3 +127,72 @@ The result of aggregate should pass the lint
 
   $ cat aggr.md | okra lint
   [OK]: <stdin>
+
+We used to report on workitems and now we use objectives.
+
+During the transition, using workitems makes the linting fail
+and the error message points to the corresponding objective.
+
+  $ mkdir -p xxx/data
+  $ cp db.csv xxx/data
+  $ cat > xxx/data/team-objectives.csv << EOF
+  > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
+  > "#558","Property-Based Testing for Multicore","In Progress","Q2 2024","Compiler & Language","Compiler","","","Proposal",""
+  > "#677","Improve OCaml experience on Windows","Todo","Q2 2024","Multicore applications","Ecosystem","","","",""
+  > "#701","JSOO Effect Performance","","Q2 2024","Compiler & Language","Compiler","","","focus/technology,level/team",""
+  > EOF
+
+This weekly is using using workitems:
+
+  $ mkdir -p xxx/weekly/2024/01
+  $ cat > xxx/weekly/2024/01/eng1.md << EOF
+  > # Last Week
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (2 days)
+  >   - This is a workitem with a parent objective in the DB
+  > 
+  > - Application and Operational Metrics (#1058)
+  >   - @eng1 (1 day)
+  >   - This is a workitem with no parent objective in the DB
+  > 
+  > - Leave
+  >   - @eng1 (2 days)
+  > EOF
+
+This weekly is using objectives:
+
+  $ mkdir -p xxx/weekly/2024/02
+  $ cat > xxx/weekly/2024/02/eng2.md << EOF
+  > # Last Week
+  > 
+  > - Property-Based Testing for Multicore (#558)
+  >   - @eng2 (2 days)
+  >   - This is an objective
+  > 
+  > - Improve OCaml experience on Windows (#677)
+  >   - @eng2 (1 day)
+  >   - This is an objective
+  > 
+  > - Leave
+  >   - @eng2 (2 days)
+  > EOF
+
+  $ okra team aggregate -C xxx -y 2024 -w 01-02 --conf conf.yml
+  # Last Week
+  
+  - Application and Operational Metrics (#1058)
+    - @eng1 (1 day)
+    - This is a workitem with no parent objective in the DB
+  
+  - Property-Based Testing for Multicore (#558)
+    - @eng1 (2 days), @eng2 (2 days)
+    - This is a workitem with a parent objective in the DB
+    - This is an objective
+  
+  - Improve OCaml experience on Windows (#677)
+    - @eng2 (1 day)
+    - This is an objective
+  
+  - Leave
+    - @eng1 (2 days), @eng2 (2 days)

--- a/test/cram/team-aggregate.t/run.t
+++ b/test/cram/team-aggregate.t/run.t
@@ -115,7 +115,7 @@ The result of aggregate should pass the lint
   > "#1115","General okra maintenance","Draft","","","","Maintenance - internal tooling","","pillar/ecosystem,team/internal-tooling",""
   > EOF
 
-  $ okra team aggregate --okr-db db.csv -C xxx -y 2024 -w 10 --conf conf.yml > aggr.md
+  $ okra team aggregate --work-item-db db.csv -C xxx -y 2024 -w 10 --conf conf.yml > aggr.md
 
   $ cat aggr.md
   # Last week

--- a/test/test_filter.ml
+++ b/test/test_filter.ml
@@ -46,7 +46,7 @@ let kr3 =
   let kind = KR.Kind.Work (KR.Work.v ~title:t3 ~id:(ID id3) ~quarter:None) in
   KR.v ~kind ~project:p2 ~objective:o2 ~time_entries:te3 []
 
-let report () = Okra.Report.of_krs [ kr1; kr2; kr3 ]
+let report () = fst @@ Okra.Report.of_krs [ kr1; kr2; kr3 ]
 
 let filter ?include_projects ?exclude_projects ?include_objectives
     ?exclude_objectives ?include_krs ?exclude_krs ?include_engineers

--- a/test/test_reports.ml
+++ b/test/test_reports.ml
@@ -19,7 +19,7 @@ module T = Okra.Time
 let aggregate f =
   let ic = open_in f in
   let omd = Omd.of_channel ic in
-  let p = Okra.Report.of_markdown omd in
+  let p, _warnings = Okra.Report.of_markdown omd in
   close_in ic;
   p
 


### PR DESCRIPTION
fix #167
also fixes #159 

I've been trying a few things, the issue in making the linter more strict right now, is that older reports won't pass the linting unless we maintain a double-check (depending on the submitted date for example, e.g. like versioning the checks), which is the same problem as linting files that contain closed workitems, these files should pass the linting, but we should print a warning (see #170).

So I've opted for printing warnings when reporting on a workitem instead of an objective, and telling the user which objective to use if there is one.

The examples are in `test/cram/lint/db.t`

What do you think?