### PR TITLE
lint: fail if the placeholder text 'Work Item 1' if still present in the report

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- Lint: fail if the placeholder text "Work Item 1" is still present in the report (#<PR_NUMBER>, @gpetiot)
 - Lint: check that the total of days reported for each engineer is 5 days (#178, @gpetiot)
 - No special treatment for "OKR Updates" sections in reports (#211, @gpetiot)
 - Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#210, @gpetiot)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- Lint: fail if the placeholder text "Work Item 1" is still present in the report (#<PR_NUMBER>, @gpetiot)
+- Lint: fail if the placeholder text "Work Item 1" is still present in the report (#221, @gpetiot)
 - Lint: check that the total of days reported for each engineer is 5 days (#178, @gpetiot)
 - No special treatment for "OKR Updates" sections in reports (#211, @gpetiot)
 - Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (#210, @gpetiot)

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -48,6 +48,8 @@ let fail_fmt_patterns =
        bullet marker." );
     ( Str.regexp "^[ ]+#",
       "Space found before title marker #. Start titles in first column." );
+    ( Str.regexp "^[ ]+- Work Item 1",
+      "Placeholder text detected. Replace with actual activity." );
   ]
 
 let pp_error ppf = function

--- a/test/cram/lint/features.t
+++ b/test/cram/lint/features.t
@@ -57,3 +57,19 @@ When errors are found in several files, they are all printed:
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
   [1]
+
+A warning is emitted when the generated report contains placeholder text:
+
+  $ cat > err.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  >   - Work Item 1
+  > EOF
+  $ okra lint err.md
+  [ERROR(S)]: err.md
+  
+  Line 5: Placeholder text detected. Replace with actual activity.
+  1 formatting errors found. Parsing aborted.
+  [1]


### PR DESCRIPTION
Fix #143