### PR TITLE
Remove handling of project field (not in masterdb)

### DIFF
--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -226,7 +226,6 @@ let update_from_master_db t db =
             id = ID db_kr.printable_id;
             title = db_kr.title;
             objective = db_kr.objective;
-            project = db_kr.project;
           }
         in
         (* show the warnings *)

--- a/lib/masterdb.ml
+++ b/lib/masterdb.ml
@@ -28,7 +28,6 @@ type elt_t = {
   printable_id : string;
   title : string;
   objective : string;
-  project : string;
   team : string;
   status : status_t option;
 }
@@ -83,7 +82,6 @@ let load_csv ?(separator = ',') f =
               printable_id;
               title = find_and_trim "title" |> normalise_title;
               objective = find_and_trim "objective";
-              project = find_and_trim "project";
               team = find_and_trim "team";
               status = find_and_trim "status" |> status_of_string;
             }

--- a/lib/masterdb.mli
+++ b/lib/masterdb.mli
@@ -28,7 +28,6 @@ type elt_t = private {
   printable_id : string;
   title : string;
   objective : string;
-  project : string;
   team : string;
   status : status_t option;
 }

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -4,11 +4,11 @@ Master DB
 When `--okr-db` is passed, metadata is fixed.
 
   $ cat > okrs.csv << EOF
-  > id,title,objective,status,team,project
-  > KR1,Actual title,Actual objective,active,team1,Actual project
-  > Kr2,Actual title 2,Actual objective,active,team1,Actual project
-  > KR3,Dropped KR,Actual objective,dropped,team2,Actual project
-  > KR5,Missing status KR,Actual objective,,team2,Actual project
+  > id,title,objective,status,team
+  > KR1,Actual title,Actual objective,active,team1
+  > Kr2,Actual title 2,Actual objective,active,team1
+  > KR3,Dropped KR,Actual objective,dropped,team2
+  > KR5,Missing status KR,Actual objective,,team2
   > EOF
 
   $ okra cat --okr-db=okrs.csv << EOF
@@ -23,13 +23,10 @@ When `--okr-db` is passed, metadata is fixed.
   okra: [WARNING] Conflicting titles:
   - "Wrong title"
   - "Actual title"
-  okra: [WARNING] KR "Wrong title" appears in two projects:
-  - "Wrong project"
-  - "Actual project"
   okra: [WARNING] KR "Wrong title" appears in two objectives:
   - "Wrong objective"
   - "Actual objective"
-  # Actual project
+  # Wrong project
   
   ## Actual objective
   
@@ -50,14 +47,8 @@ It is possible to filter by team.
   >   - @a (1 day)
   >   - Did more of the things
   > EOF
-  okra: [WARNING] KR "Actual title" appears in two projects:
-  - "Project"
-  - "Actual project"
   okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
-  okra: [WARNING] KR "Dropped KR" appears in two projects:
-  - "Project"
-  - "Actual project"
-  # Actual project
+  # Project
   
   ## Actual objective
   
@@ -78,14 +69,8 @@ It is possible to filter on more than one team.
   >   - @a (1 day)
   >   - Did more of the things
   > EOF
-  okra: [WARNING] KR "Actual title" appears in two projects:
-  - "Project"
-  - "Actual project"
   okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
-  okra: [WARNING] KR "Dropped KR" appears in two projects:
-  - "Project"
-  - "Actual project"
-  # Actual project
+  # Project
   
   ## Actual objective
   

--- a/test/cram/cat/merge.t
+++ b/test/cram/cat/merge.t
@@ -66,13 +66,7 @@ Behaviour without a database
 Behaviour with a database
 
   $ cat eng1.md eng2.md | okra cat --okr-db=okrs.csv --engineer > agg.md && cat agg.md
-  okra: [WARNING] KR "A Kr" appears in two projects:
-  - "Last Week"
-  - "Actual project"
-  okra: [WARNING] KR "A Kr" appears in two projects:
-  - "Last Week"
-  - "Actual project"
-  # Actual project
+  # Last Week
   
   ## Actual objective
   
@@ -82,13 +76,7 @@ Behaviour with a database
     - Some other work
 
   $ okra cat --okr-db=okrs.csv --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
-  okra: [WARNING] KR "A Kr" appears in two projects:
-  - "Last Week"
-  - "Actual project"
-  okra: [WARNING] KR "A Different Kr" appears in two projects:
-  - "Last Week"
-  - "Actual project"
-  # Actual project
+  # Last Week
   
   ## Actual objective
   


### PR DESCRIPTION
Removing some unreachable code and tests, as the `project` field is neither in db.csv or in team-objectives.csv.