### PR TITLE
Lint: check the quarter of workitems instead of their status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- Lint: check the quarter instead of the status (#228, @gpetiot)
+- Lint: check the quarter of workitems instead of their status (#228, @gpetiot)
 
 ## 0.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Changed
+
+- Lint: check the quarter instead of the status (#228, @gpetiot)
+
 ## 0.5.0
 
 ### Changed

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -30,7 +30,7 @@ let pp_status style ppf s = Fmt.(pf ppf "[%a]" style s)
 let run conf =
   let collect_errors name ic =
     match
-      Okra.Lint.lint ?okr_db:(Common.okr_db conf.c)
+      Okra.Lint.lint ~filename:name ?okr_db:(Common.okr_db conf.c)
         ?check_time:(Common.check_time conf.c)
         ~include_sections:(Common.include_sections conf.c)
         ~ignore_sections:(Common.ignore_sections conf.c)

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -226,6 +226,7 @@ let update_from_master_db t db =
             id = ID db_kr.printable_id;
             title = db_kr.title;
             objective = db_kr.objective;
+            quarter = db_kr.quarter;
           }
         in
         (* show the warnings *)

--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -33,6 +33,7 @@ type t = {
   objective : string;
   title : string;
   id : id;
+  quarter : Quarter.t option;
   time_entries : (string * Time.t) list list;
   time_per_engineer : (string, Time.t) Hashtbl.t;
   work : Item.t list list;
@@ -45,7 +46,7 @@ let counter =
     incr c;
     i
 
-let v ~project ~objective ~title ~id ~time_entries work =
+let v ~project ~objective ~title ~id ~quarter ~time_entries work =
   let counter = counter () in
   (* Sum time per engineer *)
   let time_per_engineer =
@@ -66,6 +67,7 @@ let v ~project ~objective ~title ~id ~time_entries work =
     objective;
     title;
     id;
+    quarter;
     time_entries;
     time_per_engineer;
     work;
@@ -128,6 +130,16 @@ let merge x y =
               l "KR %S appears in two objectives:\n- %S\n- %S" title x y);
         x
   in
+  let quarter =
+    match (x.quarter, y.quarter) with
+    | None, q | q, None -> q
+    | Some x, Some y ->
+        if Quarter.compare x y <> 0 then
+          Log.warn (fun l ->
+              l "KR %S appears in two quarters:\n- %a\n- %a" title Quarter.pp x
+                Quarter.pp y);
+        Some x
+  in
   let id =
     match (x.id, y.id) with
     | ID x, ID y ->
@@ -162,6 +174,7 @@ let merge x y =
     objective;
     title;
     id;
+    quarter;
     time_entries;
     time_per_engineer;
     work;
@@ -207,19 +220,6 @@ let update_from_master_db t db =
           Log.warn (fun l ->
               l "KR ID updated from \"No KR\" to %S:\n- %S\n- %S" db_kr.id
                 orig_kr.title db_kr.title);
-        (match db_kr.status with
-        | Some Active -> ()
-        | Some s ->
-            Log.warn (fun l ->
-                l "Work logged on KR marked as %S: %S (%S)"
-                  (Masterdb.string_of_status s)
-                  db_kr.title db_kr.id)
-        | None ->
-            Log.warn (fun l ->
-                l
-                  "Work logged on KR with no status set, status should be \
-                   Active: %S (%S)"
-                  db_kr.title db_kr.id));
         let kr =
           {
             orig_kr with

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -33,6 +33,7 @@ type t = private {
   objective : string;
   title : string;
   id : id;
+  quarter : Quarter.t option;
   time_entries : (string * Time.t) list list;
   time_per_engineer : (string, Time.t) Hashtbl.t;
   work : Item.t list list;
@@ -43,6 +44,7 @@ val v :
   objective:string ->
   title:string ->
   id:id ->
+  quarter:Quarter.t option ->
   time_entries:(string * Time.t) list list ->
   Item.t list list ->
   t

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra-lib)
- (libraries logs omd fmt re calendar csv get-activity-lib gitlab))
+ (libraries logs omd fmt fpath re calendar csv get-activity-lib gitlab))

--- a/lib/filter.ml
+++ b/lib/filter.ml
@@ -140,7 +140,7 @@ let apply f (t : Report.t) =
               in
               let kr =
                 KR.v ~project:kr.project ~objective:kr.objective ~title:kr.title
-                  ~time_entries ~id:kr.id work
+                  ~time_entries ~id:kr.id ~quarter:kr.quarter work
               in
               Report.add new_t kr
         in

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -28,6 +28,7 @@ type lint_error =
   | No_project_found of int option * string
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
+  | Invalid_quarter of { expected : Quarter.t; found : Quarter.t; kr : KR.t }
 
 type lint_result = (unit, lint_error list) result
 
@@ -96,6 +97,11 @@ let pp_error ppf = function
       Fmt.pf ppf "Missing includes section: %a\n" Fmt.(list ~sep:comma string) s
   | Invalid_markdown_in_work_items (_, s) ->
       Fmt.pf ppf "@[<hv 2>Invalid markdown in work items:@ %s@]@," s
+  | Invalid_quarter { expected; found; kr } ->
+      Fmt.pf ppf
+        "@[<hv 2>In WI %S:@ Work logged on WI scheduled for %a (please use a \
+         WI scheduled for %a)@]@,"
+        kr.title Quarter.pp found Quarter.pp expected
 
 let string_of_error = Fmt.to_to_string pp_error
 
@@ -150,9 +156,23 @@ let check_total_time ?check_time (krs : KR.t list) =
           else Error (Invalid_total_time (name, time)))
         tbl (Ok ())
 
+let check_quarter (quarter : Quarter.t option) (kr : KR.t) =
+  match (quarter, kr.quarter) with
+  | None, _ | _, None -> Ok ()
+  | Some q, Some kr_q ->
+      Error (Invalid_quarter { expected = q; found = kr_q; kr })
+
+let check_quarters quarter krs warnings =
+  List.fold_left
+    (fun acc kr ->
+      match check_quarter quarter kr with Ok () -> acc | Error w -> w :: acc)
+    warnings krs
+
 (* Parse document as a string to check for aggregation errors (assumes no
    formatting errors) *)
-let check_document ?okr_db ~include_sections ~ignore_sections ?check_time s =
+let check_document ?okr_db ~include_sections ~ignore_sections ?check_time
+    ~filename s =
+  let quarter = Quarter.of_filename ~filename in
   let lines =
     String.split_on_char '\n' s |> List.mapi (fun i s -> (i + 1, s))
   in
@@ -166,6 +186,7 @@ let check_document ?okr_db ~include_sections ~ignore_sections ?check_time s =
     | Ok () -> warnings
     | Error w -> w :: warnings
   in
+  let warnings = check_quarters quarter okrs warnings in
   match warnings with
   | [] ->
       let _report = Report.of_krs ?okr_db okrs in
@@ -173,17 +194,19 @@ let check_document ?okr_db ~include_sections ~ignore_sections ?check_time s =
   | warnings -> Error warnings
 
 let document_ok ?okr_db ~include_sections ~ignore_sections ~format_errors
-    ?check_time s =
+    ?check_time ~filename s =
   if !format_errors <> [] then
     Error
       [
         Format_error
           (List.sort (fun (x, _) (y, _) -> compare x y) !format_errors);
       ]
-  else check_document ?okr_db ~include_sections ~ignore_sections ?check_time s
+  else
+    check_document ?okr_db ~include_sections ~ignore_sections ?check_time
+      ~filename s
 
 let lint_string_list ?okr_db ?(include_sections = []) ?(ignore_sections = [])
-    ?check_time lines =
+    ?check_time ~filename lines =
   let format_errors = ref [] in
   let rec check_and_read buf pos = function
     | [] -> Buffer.contents buf
@@ -195,10 +218,10 @@ let lint_string_list ?okr_db ?(include_sections = []) ?(ignore_sections = [])
   in
   let s = check_and_read (Buffer.create 1024) 1 lines in
   document_ok ?okr_db ~include_sections ~ignore_sections ~format_errors
-    ?check_time s
+    ?check_time ~filename s
 
-let lint ?okr_db ?(include_sections = []) ?(ignore_sections = []) ?check_time ic
-    =
+let lint ?okr_db ?(include_sections = []) ?(ignore_sections = []) ?check_time
+    ~filename ic =
   let format_errors = ref [] in
   let rec check_and_read buf ic pos =
     try
@@ -213,7 +236,7 @@ let lint ?okr_db ?(include_sections = []) ?(ignore_sections = []) ?check_time ic
   in
   let s = check_and_read (Buffer.create 1024) ic 1 in
   document_ok ?okr_db ~include_sections ~ignore_sections ~format_errors
-    ?check_time s
+    ?check_time ~filename s
 
 let short_messages_of_error file_name =
   let short_message line_number msg =
@@ -246,3 +269,6 @@ let short_messages_of_error file_name =
       short_messagef None "Missing includes section: %s" (String.concat ", " l)
   | Invalid_markdown_in_work_items (line_number, s) ->
       short_messagef line_number "Invalid markdown in work items: %s" s
+  | Invalid_quarter { expected = _; found; kr } ->
+      short_messagef None "Using KR of invalid quarter: %S (%a)" kr.title
+        Quarter.pp found

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -26,6 +26,7 @@ type lint_error =
   | No_project_found of int option * string
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
+  | Invalid_quarter of { expected : Quarter.t; found : Quarter.t; kr : KR.t }
 
 type lint_result = (unit, lint_error list) result
 
@@ -34,6 +35,7 @@ val lint :
   ?include_sections:string list ->
   ?ignore_sections:string list ->
   ?check_time:Time.t ->
+  filename:string ->
   in_channel ->
   lint_result
 
@@ -42,6 +44,7 @@ val lint_string_list :
   ?include_sections:string list ->
   ?ignore_sections:string list ->
   ?check_time:Time.t ->
+  filename:string ->
   string list ->
   lint_result
 (** [lint_string_list] is like {!lint} except the input is a list of lines *)

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -26,7 +26,7 @@ type lint_error =
   | No_project_found of int option * string
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
-  | Invalid_quarter of { expected : Quarter.t; found : Quarter.t; kr : KR.t }
+  | Invalid_quarter of KR.t
 
 type lint_result = (unit, lint_error list) result
 

--- a/lib/masterdb.ml
+++ b/lib/masterdb.ml
@@ -30,6 +30,7 @@ type elt_t = {
   objective : string;
   team : string;
   status : status_t option;
+  quarter : Quarter.t option;
 }
 
 type t = (string, elt_t) Hashtbl.t
@@ -76,6 +77,7 @@ let load_csv ?(separator = ',') f =
           line := !line + 1;
           let find_and_trim col = Csv.Row.find row col |> String.trim in
           let printable_id = find_and_trim "id" in
+          let* quarter = find_and_trim "quarter" |> Quarter.of_string in
           let e =
             {
               id = String.uppercase_ascii printable_id;
@@ -84,6 +86,7 @@ let load_csv ?(separator = ',') f =
               objective = find_and_trim "objective";
               team = find_and_trim "team";
               status = find_and_trim "status" |> status_of_string;
+              quarter;
             }
           in
           if e.id = "" then

--- a/lib/masterdb.mli
+++ b/lib/masterdb.mli
@@ -30,6 +30,7 @@ type elt_t = private {
   objective : string;
   team : string;
   status : status_t option;
+  quarter : Quarter.t option;
 }
 
 type t = (string, elt_t) Hashtbl.t

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -254,9 +254,12 @@ let kr ~project ~objective = function
       let project = String.trim project in
       if project = "" then err_no_project title;
       let objective = String.trim objective in
+      let quarter = None in
 
       (* Construct final entry *)
-      let kr = KR.v ~project ~objective ~title ~id ~time_entries work in
+      let kr =
+        KR.v ~project ~objective ~title ~id ~time_entries ~quarter work
+      in
       Some kr
 
 let block_okr = function

--- a/lib/quarter.ml
+++ b/lib/quarter.ml
@@ -53,3 +53,8 @@ let of_filename ~filename =
           | _ -> None)
       | None -> None)
   | _ -> None
+
+let check q kr_q =
+  match (q, kr_q) with
+  | None, _ | _, None -> true
+  | Some q, Some kr_q -> compare q kr_q = 0

--- a/lib/quarter.ml
+++ b/lib/quarter.ml
@@ -1,0 +1,55 @@
+type t = { year : int; quarter : [ `Q1 | `Q2 | `Q3 | `Q4 ] }
+
+let pp ppf x =
+  let pp_quarter ppf = function
+    | `Q1 -> Fmt.pf ppf "Q1"
+    | `Q2 -> Fmt.pf ppf "Q2"
+    | `Q3 -> Fmt.pf ppf "Q3"
+    | `Q4 -> Fmt.pf ppf "Q4"
+  in
+  Fmt.pf ppf "%i %a" x.year pp_quarter x.quarter
+
+let compare x y =
+  match Int.compare x.year y.year with
+  | 0 -> compare x.quarter y.quarter
+  | x -> x
+
+let of_string s =
+  let err_msg = Error (`Msg (Fmt.str "invalid quarter %S" s)) in
+  match String.split_on_char ' ' s with
+  | [] -> Ok None
+  | [ "" ] -> Ok None
+  | [ "Rolling" ] -> Ok None
+  | quarter :: year :: _ -> (
+      match int_of_string_opt year with
+      | Some year -> (
+          match quarter with
+          | "Q1" -> Ok (Some { year; quarter = `Q1 })
+          | "Q2" -> Ok (Some { year; quarter = `Q2 })
+          | "Q3" -> Ok (Some { year; quarter = `Q3 })
+          | "Q4" -> Ok (Some { year; quarter = `Q4 })
+          | _ -> err_msg)
+      | None -> err_msg)
+  | _ -> err_msg
+
+let of_filename ~filename =
+  let segs = Fpath.segs (Fpath.v filename) in
+  let rec strip_prefix = function
+    | [] -> []
+    | "weekly" :: _ as x -> x
+    | _ :: x -> strip_prefix x
+  in
+  let segs = strip_prefix segs in
+  match segs with
+  | [ "weekly"; year; week; _file ] -> (
+      match int_of_string_opt year with
+      | Some year -> (
+          (* each quarter is 13 weeks, either 4-4-5, 4-5-4, or 5-4-4 *)
+          match int_of_string_opt week with
+          | Some x when 1 <= x && x <= 13 -> Some { year; quarter = `Q1 }
+          | Some x when 14 <= x && x <= 26 -> Some { year; quarter = `Q2 }
+          | Some x when 27 <= x && x <= 39 -> Some { year; quarter = `Q3 }
+          | Some x when 40 <= x && x <= 53 -> Some { year; quarter = `Q4 }
+          | _ -> None)
+      | None -> None)
+  | _ -> None

--- a/lib/quarter.mli
+++ b/lib/quarter.mli
@@ -1,0 +1,6 @@
+type t
+
+val compare : t -> t -> int
+val pp : t Fmt.t
+val of_string : string -> (t option, [ `Msg of string ]) result
+val of_filename : filename:string -> t option

--- a/lib/quarter.mli
+++ b/lib/quarter.mli
@@ -4,3 +4,4 @@ val compare : t -> t -> int
 val pp : t Fmt.t
 val of_string : string -> (t option, [ `Msg of string ]) result
 val of_filename : filename:string -> t option
+val check : t option -> t option -> bool

--- a/lib/team.ml
+++ b/lib/team.ml
@@ -50,7 +50,7 @@ let lint_member_week admin_dir member ~week ~year =
            mode. *)
         match
           Lint.lint ~include_sections:[ "Last week" ] ~ignore_sections:[] ic
-            ~check_time:(Time.days 5.)
+            ~check_time:(Time.days 5.) ~filename:fname
         with
         | Ok () -> Complete
         | Error e -> Not_lint e)

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -4,11 +4,11 @@ Master DB
 When `--okr-db` is passed, metadata is fixed.
 
   $ cat > okrs.csv << EOF
-  > id,title,objective,status,team
-  > KR1,Actual title,Actual objective,active,team1
-  > Kr2,Actual title 2,Actual objective,active,team1
-  > KR3,Dropped KR,Actual objective,dropped,team2
-  > KR5,Missing status KR,Actual objective,,team2
+  > id,title,objective,status,team,quarter
+  > KR1,Actual title,Actual objective,active,team1,"Q1 2023 - Jan-Mar"
+  > Kr2,Actual title 2,Actual objective,active,team1,"Q2 2021 - Apr-Jun"
+  > KR3,Dropped KR,Actual objective,dropped,team2,"Q2 2024 - Apr-Jun"
+  > KR5,Missing status KR,Actual objective,,team2,"Rolling"
   > EOF
 
   $ okra cat --okr-db=okrs.csv << EOF
@@ -47,7 +47,6 @@ It is possible to filter by team.
   >   - @a (1 day)
   >   - Did more of the things
   > EOF
-  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
   # Project
   
   ## Actual objective
@@ -69,7 +68,6 @@ It is possible to filter on more than one team.
   >   - @a (1 day)
   >   - Did more of the things
   > EOF
-  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
   # Project
   
   ## Actual objective
@@ -233,8 +231,6 @@ Warn when using KRs that are not active or missing status
   >   - Did more of the things
   > 
   > EOF
-  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
-  okra: [WARNING] Work logged on KR with no status set, status should be Active: "Missing status KR" ("KR5")
   # Actual project
   
   ## Actual objective

--- a/test/cram/lint/db.t
+++ b/test/cram/lint/db.t
@@ -1,6 +1,8 @@
 Workitems can be checked when a DB of this form is provided:
 
   $ mkdir -p admin/data
+  $ mkdir -p admin/weekly/2023/50
+  $ mkdir -p admin/weekly/2024/01
 
   $ cat > admin/data/db.csv << EOF
   > "id","title","status","quarter","team","pillar","objective","funder","labels","progress"
@@ -13,6 +15,63 @@ Workitems can be checked when a DB of this form is provided:
   > "#1090","Property-Based Testing for Multicore","Active 🏗","Q1 2024 - Jan - Mar","Compiler and language","Compiler","Property-Based Testing for Multicore","","pillar/compiler,team/compiler&language,Proposal","25."
   > "#1115","General okra maintenance","Draft","","","","Maintenance - internal tooling","","pillar/ecosystem,team/internal-tooling",""
   > EOF
+
+  $ cat > admin/weekly/2023/50/eng1.md << EOF
+  > # Last week
+  > 
+  > - Application and Operational Metrics (#1058)
+  >   - @eng1 (2 days)
+  >   - Something
+  > 
+  > - Property-Based Testing for Multicore (#1090)
+  >   - @eng1 (1 day)
+  >   - Something
+  > 
+  > - General okra maintenance (#1115)
+  >   - @eng1 (1 day)
+  >   - Something
+  > 
+  > - Leave (#1074)
+  >   - @eng1 (1 day)
+  >   - off
+  > EOF
+
+  $ cat > admin/weekly/2023/50/eng2.md << EOF
+  > # Last week
+  > 
+  > - Application and Operational Metrics (#1058)
+  >   - @eng2 (2 days)
+  >   - Something
+  > 
+  > - General okra maintenance (#1115)
+  >   - @eng2 (2 days)
+  >   - Something
+  > 
+  > - Leave (#1074)
+  >   - @eng2 (1 day)
+  >   - off
+  > EOF
+
+  $ okra lint -e -C admin admin/weekly/2023/50/eng1.md
+  [ERROR(S)]: admin/weekly/2023/50/eng1.md
+  
+  In WI "Property-Based Testing for Multicore":
+    Work logged on WI scheduled for 2024 Q1
+  [1]
+
+  $ okra lint -e -C admin admin/weekly/2023/50/eng2.md
+  [OK]: admin/weekly/2023/50/eng2.md
+
+  $ cat > admin/weekly/2024/01/eng1.md << EOF
+  > EOF
+  $ cp admin/weekly/2023/50/eng1.md admin/weekly/2024/01/eng1.md
+
+  $ okra lint -e -C admin admin/weekly/2024/01/eng1.md
+  [ERROR(S)]: admin/weekly/2024/01/eng1.md
+  
+  In WI "Application and Operational Metrics":
+    Work logged on WI scheduled for 2023 Q4
+  [1]
 
   $ cat > weekly.md << EOF
   > # Last week

--- a/test/cram/lint/db.t
+++ b/test/cram/lint/db.t
@@ -62,8 +62,6 @@ Workitems can be checked when a DB of this form is provided:
   $ okra lint -e -C admin admin/weekly/2023/50/eng2.md
   [OK]: admin/weekly/2023/50/eng2.md
 
-  $ cat > admin/weekly/2024/01/eng1.md << EOF
-  > EOF
   $ cp admin/weekly/2023/50/eng1.md admin/weekly/2024/01/eng1.md
 
   $ okra lint -e -C admin admin/weekly/2024/01/eng1.md

--- a/test/cram/lint/db.t
+++ b/test/cram/lint/db.t
@@ -45,18 +45,14 @@ No check on WIs without the DB:
 The DB can be passed through the [--okr-db] option:
 
   $ okra lint -e --okr-db admin/data/db.csv weekly.md
-  okra: [WARNING] Work logged on KR marked as "Dropped": "Multicore OCaml Merlin project" ("#1053")
   okra: [WARNING] Conflicting titles:
   - "Invalid name"
   - "Property-Based Testing for Multicore"
-  okra: [WARNING] Work logged on KR marked as "Draft": "General okra maintenance" ("#1115")
   [OK]: weekly.md
 
 The DB can be looked up in the [repo-dir] passed through the [-C]/[--repo-dir] option:
   $ okra lint -e -C admin weekly.md
-  okra: [WARNING] Work logged on KR marked as "Dropped": "Multicore OCaml Merlin project" ("#1053")
   okra: [WARNING] Conflicting titles:
   - "Invalid name"
   - "Property-Based Testing for Multicore"
-  okra: [WARNING] Work logged on KR marked as "Draft": "General okra maintenance" ("#1115")
   [OK]: weekly.md

--- a/test/test_filter.ml
+++ b/test/test_filter.ml
@@ -35,13 +35,16 @@ let id2 = "Id2"
 let id3 = "ID3"
 
 let kr1 =
-  KR.v ~project:p1 ~objective:o1 ~title:t1 ~id:KR.New_KR ~time_entries:te1 []
+  KR.v ~project:p1 ~objective:o1 ~title:t1 ~id:KR.New_KR ~time_entries:te1
+    ~quarter:None []
 
 let kr2 =
-  KR.v ~project:p2 ~objective:o2 ~title:t2 ~id:(ID id2) ~time_entries:te2 []
+  KR.v ~project:p2 ~objective:o2 ~title:t2 ~id:(ID id2) ~time_entries:te2
+    ~quarter:None []
 
 let kr3 =
-  KR.v ~project:p2 ~objective:o2 ~title:t3 ~id:(ID id3) ~time_entries:te3 []
+  KR.v ~project:p2 ~objective:o2 ~title:t3 ~id:(ID id3) ~time_entries:te3
+    ~quarter:None []
 
 let report () = Okra.Report.of_krs [ kr1; kr2; kr3 ]
 


### PR DESCRIPTION
Fix #170

The goal is to be able to lint older weeklies, by checking the `quarter` field instead of the `status` (that gets `completed` eventually). I will add some tests but beta-testers would be welcome.