### PR TITLE
Mention unpinning okra-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Then you can install okra. If you had it installed previously through pinning si
 opam pin remove okra
 ```
 
-(This will both remove the pinned version and install the new one.)
+This will both remove the pinned version and install the new one. You may also need to
+`opam pin remove okra-lib` too.
 
 If okra is not installed yet, run:
 ```sh


### PR DESCRIPTION
It took me ages to work out why my `opam install okra` wasn't working. Turns out `okra-lib` was still pinned to `dev` and this meant the version of `okra` being installed was version `0.1` which couldn't find `get-activity` the library etc.