### PR TITLE
Allow engineers to specify the number of working days

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 - Lint: check the quarter of workitems instead of their status (#228, @gpetiot)
 
+### Added
+
+- Allow engineers to specify the number of working days (#232, @patricoferris)
+
 ## 0.5.0
 
 ### Changed

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -333,7 +333,12 @@ let term =
   and+ output = output
   and+ repo = repo
   and+ engineer_report = engineer_report in
-  let check_time = if engineer_report then Some (Okra.Time.days 5.) else None in
+  let check_time =
+    match Conf.work_days_in_a_week conf with
+    | Some f when engineer_report -> Some (Okra.Time.days f)
+    | _ when engineer_report -> Some (Okra.Time.days 5.)
+    | _ -> None
+  in
   {
     okr_db;
     filter;

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -48,6 +48,7 @@ type t = {
   okr_db : string option;
   admin_dir : string option;
   gitlab_token : string option;
+  work_days_in_a_week : float option;
 }
 [@@deriving yaml]
 
@@ -59,6 +60,7 @@ let default =
     okr_db = None;
     admin_dir = None;
     gitlab_token = None;
+    work_days_in_a_week = None;
   }
 
 let teams { teams; _ } =
@@ -78,6 +80,7 @@ let footer { footer; _ } = footer
 let okr_db t = t.okr_db
 let admin_dir t = t.admin_dir
 let gitlab_token t = t.gitlab_token
+let work_days_in_a_week t = t.work_days_in_a_week
 
 let load file =
   let open Rresult in

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -38,6 +38,11 @@ val gitlab_token : t -> string option
 (** [gitlab_token] is the optional Gitlab token, if present your Gitlab activity
     will also be queried. *)
 
+val work_days_in_a_week : t -> float option
+(** [work_days_in_a_week] is an optional override for the number of days you work 
+    in a given week, this is useful for contractors so [okra lint -e] doesn't report
+    errors for working less than five days a week. *)
+
 val load : string -> (t, [ `Msg of string ]) result
 (** [load file] attempts to load a configuration from [file] *)
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -19,7 +19,7 @@ type lint_error =
   | Format_error of (int * string) list
   | No_time_found of int option * string
   | Invalid_time of { lnum : int option; title : string; entry : string }
-  | Invalid_total_time of string * Time.t
+  | Invalid_total_time of string * Time.t * Time.t
   | Multiple_time_entries of int option * string
   | No_work_found of int option * string
   | No_KR_ID_found of int option * string

--- a/test/cram/lint/time.t
+++ b/test/cram/lint/time.t
@@ -82,3 +82,28 @@ Valid time
   >   - My work
   > EOF
   [OK]: <stdin>
+
+Using the configuration file to change the default number of working days.
+
+  $ cat > valid-conf.yaml << EOF
+  > work_days_in_a_week: 1.5
+  > EOF
+  $ okra lint --engineer --conf valid-conf.yaml << EOF
+  > # Last week
+  > 
+  > - This is a KR (KR1)
+  >   - @eng1 (1.5 days)
+  >   - My work
+  > EOF
+  [OK]: <stdin>
+  $ okra lint --engineer --conf valid-conf.yaml << EOF
+  > # Last week
+  > 
+  > - This is a KR (KR1)
+  >   - @eng1 (0.5 days)
+  >   - My work
+  > EOF
+  [ERROR(S)]: <stdin>
+  
+  Invalid total time found for eng1 (reported 0.5 days, expected 1.5 days).
+  [1]


### PR DESCRIPTION
Not sure if this feature is desired as it is probably quite niche, but not everyone is working 5 days a week by default. This allows Okra to be configured with a different expected number of working days per week. The default is still `5`.