### PR TITLE
Cleanup parsing and linting error messages

### DIFF
--- a/lib/KR.ml
+++ b/lib/KR.ml
@@ -358,9 +358,37 @@ let make_time_entries t =
   let aux (e, d) = Fmt.str "@%s (%a)" e Time.pp d in
   Item.[ Paragraph (Text (String.concat ", " (List.map aux t))) ]
 
-type warning =
-  | Objective_not_found of Work.t
-  | Migration of { work_item : Work.t; objective : Work.t option }
+module Warning = struct
+  type t =
+    | Objective_not_found of Work.t
+    | Migration of { work_item : Work.t; objective : Work.t option }
+
+  let pp ppf = function
+    | Objective_not_found x -> Fmt.pf ppf "Invalid objective:@ %S" x.title
+    | Migration { work_item; objective = None } ->
+        Fmt.pf ppf
+          "Invalid objective:@ \"%a\" is a work-item, you should use an \
+           objective instead"
+          Work.pp work_item
+    | Migration { work_item; objective = Some obj } ->
+        Fmt.pf ppf
+          "Invalid objective:@ \"%a\" is a work-item, you should use its \
+           parent objective \"%a\" instead"
+          Work.pp work_item Work.pp obj
+
+  let pp_short ppf = function
+    | Objective_not_found x -> Fmt.pf ppf "Invalid objective: %S" x.title
+    | Migration { work_item; objective = None } ->
+        Fmt.pf ppf
+          "Invalid objective:@ \"%a\" is a work-item, an objective should be \
+           used instead"
+          Work.pp work_item
+    | Migration { work_item; objective = Some obj } ->
+        Fmt.pf ppf
+          "Invalid objective:@ \"%a\" is a work-item, its parent objective \
+           \"%a\" should be used instead"
+          Work.pp work_item Work.pp obj
+end
 
 let update_from_master_db orig_kr db =
   match orig_kr.kind with
@@ -378,7 +406,7 @@ let update_from_master_db orig_kr db =
                 l "KR ID not found for new KR %S" orig_work.title);
           match db.work_item_db with
           (* Not found in objectives, no WI database *)
-          | None -> (orig_kr, Some (Objective_not_found orig_work))
+          | None -> (orig_kr, Some (Warning.Objective_not_found orig_work))
           | Some work_item_db -> (
               match
                 Masterdb.Work_item.find_title_opt work_item_db orig_work.title

--- a/lib/KR.mli
+++ b/lib/KR.mli
@@ -77,11 +77,16 @@ module Id : sig
   val compare : t -> t -> int
 end
 
-type warning =
-  | Objective_not_found of Work.t
-  | Migration of { work_item : Work.t; objective : Work.t option }
-      (** For retro-compatibility only.
-          This case should be removed once everything has migrated to objectives. *)
+module Warning : sig
+  type t =
+    | Objective_not_found of Work.t
+    | Migration of { work_item : Work.t; objective : Work.t option }
+        (** For retro-compatibility only.
+            This case should be removed once everything has migrated to objectives. *)
+
+  val pp : t Fmt.t
+  val pp_short : t Fmt.t
+end
 
 val v :
   kind:Kind.t ->
@@ -94,7 +99,7 @@ val v :
 val dump : t Fmt.t
 val merge : t -> t -> t
 val compare : t -> t -> int
-val update_from_master_db : t -> Masterdb.t -> t * warning option
+val update_from_master_db : t -> Masterdb.t -> t * Warning.t option
 
 (** {2 Pretty-print} *)
 

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -19,13 +19,13 @@ let ( let* ) = Result.bind
 
 type lint_error =
   | Format_error of (int * string) list
-  | No_time_found of int option * string
-  | Invalid_time of { lnum : int option; title : string; entry : string }
+  | No_time_found of int option * KR.Heading.t
+  | Invalid_time of { lnum : int option; kr : KR.Heading.t; entry : string }
   | Invalid_total_time of string * Time.t * Time.t
-  | Multiple_time_entries of int option * string
-  | No_work_found of int option * string
+  | Multiple_time_entries of int option * KR.Heading.t
+  | No_work_found of int option * KR.Heading.t
   | No_KR_ID_found of int option * string
-  | No_project_found of int option * string
+  | No_project_found of int option * KR.Heading.t
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t
@@ -60,47 +60,52 @@ let pp_error ppf = function
       Fmt.pf ppf "@[<v 0>%a@,%d formatting errors found. Parsing aborted.@]"
         (Fmt.list ~sep:Fmt.sp pp_msg)
         x (List.length x)
-  | No_time_found (_, s) ->
+  | No_time_found (_, kr) ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ No time entry found. Each KR must be followed by \
-         '- @@... (x days)'@]@,"
-        s
-  | Invalid_time { lnum = _; title; entry } ->
+        "@[<hv 2>In objective \"%a\":@ No time entry found. Each objective \
+         must be followed by '- @@... (x days)'@]@,"
+        KR.Heading.pp kr
+  | Invalid_time { lnum = _; kr; entry } ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ Invalid time entry %S found. Format is '- @@eng1 \
-         (x days), @@eng2 (y days)'@ where x and y must be divisible by 0.5@]@,"
-        title entry
+        "@[<hv 2>In objective \"%a\":@ Invalid time entry %S found. Format is \
+         '- @@eng1 (x days), @@eng2 (y days)'@ where x and y must be divisible \
+         by 0.5@]@,"
+        KR.Heading.pp kr entry
   | Invalid_total_time (s, t, total) ->
       Fmt.pf ppf
         "@[<hv 2>Invalid total time found for %s (reported %a, expected %a).@]@,"
         s Time.pp t Time.pp total
-  | Multiple_time_entries (_, s) ->
+  | Multiple_time_entries (_, kr) ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ Multiple time entries found. Only one time entry \
-         should follow immediately after the KR.@]@,"
-        s
-  | No_work_found (_, s) ->
+        "@[<hv 2>In objective \"%a\":@ Multiple time entries found. Only one \
+         time entry should follow immediately after the objective.@]@,"
+        KR.Heading.pp kr
+  | No_work_found (_, kr) ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ No work items found. This may indicate an \
-         unreported parsing error. Remove the KR if it is without work.@]@,"
-        s
+        "@[<hv 2>In objective \"%a\":@ No work items found. This may indicate \
+         an unreported parsing error. Remove the objective if it is without \
+         work.@]@,"
+        KR.Heading.pp kr
   | No_KR_ID_found (_, s) ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ No KR ID found. WIs should be in the format \"This \
-         is a WI (#123)\", where 123 is the WI issue ID. Legacy KRs should be \
-         in the format \"This is a KR (PLAT123)\", where PLAT123 is the KR ID. \
-         For WIs that don't have an ID yet, use \"New WI\" and for work \
-         without a WI use \"No WI\".@]@,"
+        "@[<hv 2>In objective %S:@ No ID found. Objectives should be in the \
+         format \"This is an objective (#123)\", where 123 is the objective \
+         issue ID. For objectives that don't have an ID yet, use \"New KR\" \
+         and for work without an objective use \"No KR\".@]@,"
         s
-  | No_project_found (_, s) ->
-      Fmt.pf ppf "@[<hv 2>In KR %S:@ No project found (starting with '#')@]@," s
+  | No_project_found (_, kr) ->
+      Fmt.pf ppf
+        "@[<hv 2>In objective \"%a\":@ No project found (starting with '#')@]@,"
+        KR.Heading.pp kr
   | Not_all_includes s ->
       Fmt.pf ppf "Missing includes section: %a\n" Fmt.(list ~sep:comma string) s
   | Invalid_markdown_in_work_items (_, s) ->
-      Fmt.pf ppf "@[<hv 2>Invalid markdown in work items:@ %s@]@," s
+      Fmt.pf ppf "@[<hv 2>Invalid markdown:@ %s@]@," s
   | Invalid_quarter kr ->
-      Fmt.pf ppf "@[<hv 2>In WI %S:@ Work logged on WI scheduled for %a@]@,"
-        kr.title (Fmt.option Quarter.pp) kr.quarter
+      Fmt.pf ppf
+        "@[<hv 2>In objective \"%a\":@ Work logged on objective scheduled for \
+         %a@]@,"
+        KR.Work.pp kr (Fmt.option Quarter.pp) kr.quarter
   | Invalid_objective w -> (
       match w with
       | Objective_not_found x ->
@@ -132,14 +137,17 @@ let grep_n s lines =
     (fun (i, line) -> if Str.string_match re line 0 then Some i else None)
     lines
 
+let lines_of_kr s lines = grep_n (Fmt.str "%a" KR.Heading.pp s) lines
+
 let add_context lines = function
-  | Parser.No_time_found s -> No_time_found (grep_n s lines, s)
-  | Parser.Invalid_time { title; entry } ->
-      Invalid_time { lnum = grep_n entry lines; title; entry }
-  | Parser.Multiple_time_entries s -> Multiple_time_entries (grep_n s lines, s)
-  | Parser.No_work_found s -> No_work_found (grep_n s lines, s)
+  | Parser.No_time_found s -> No_time_found (lines_of_kr s lines, s)
+  | Parser.Invalid_time { kr; entry } ->
+      Invalid_time { lnum = grep_n entry lines; kr; entry }
+  | Parser.Multiple_time_entries s ->
+      Multiple_time_entries (lines_of_kr s lines, s)
+  | Parser.No_work_found s -> No_work_found (lines_of_kr s lines, s)
   | Parser.No_KR_ID_found s -> No_KR_ID_found (grep_n s lines, s)
-  | Parser.No_project_found s -> No_project_found (grep_n s lines, s)
+  | Parser.No_project_found s -> No_project_found (lines_of_kr s lines, s)
   | Parser.Not_all_includes_accounted_for s -> Not_all_includes s
   | Parser.Invalid_markdown_in_work_items s ->
       Invalid_markdown_in_work_items (grep_n s lines, s)
@@ -276,27 +284,29 @@ let short_messages_of_error file_name =
         (fun (line_number, message) -> short_message line_number message)
         errs
   | No_time_found (line_number, kr) ->
-      short_messagef line_number "No time found in %S" kr
-  | Invalid_time { lnum; title; entry } ->
-      short_messagef lnum "Invalid time entry %S in %S" entry title
+      short_messagef line_number "No time found in \"%a\"" KR.Heading.pp kr
+  | Invalid_time { lnum; kr; entry } ->
+      short_messagef lnum "Invalid time entry %S in \"%a\"" entry KR.Heading.pp
+        kr
   | Invalid_total_time (s, t, total) ->
       short_messagef None "Invalid total time for %S (%a/%a)" s Time.pp t
         Time.pp total
   | Multiple_time_entries (line_number, kr) ->
-      short_messagef line_number "Multiple time entries for %S" kr
+      short_messagef line_number "Multiple time entries for \"%a\""
+        KR.Heading.pp kr
   | No_work_found (line_number, kr) ->
-      short_messagef line_number "No work found for %S" kr
+      short_messagef line_number "No work found for \"%a\"" KR.Heading.pp kr
   | No_KR_ID_found (line_number, kr) ->
       short_messagef line_number "No KR ID found for %S" kr
   | No_project_found (line_number, kr) ->
-      short_messagef line_number "No project found for %S" kr
+      short_messagef line_number "No project found for \"%a\"" KR.Heading.pp kr
   | Not_all_includes l ->
       short_messagef None "Missing includes section: %s" (String.concat ", " l)
   | Invalid_markdown_in_work_items (line_number, s) ->
       short_messagef line_number "Invalid markdown in work items: %s" s
   | Invalid_quarter kr ->
-      short_messagef None "Using KR of invalid quarter: %S (%a)" kr.title
-        (Fmt.option Quarter.pp) kr.quarter
+      short_messagef None "Using KR of invalid quarter: \"%a\" (%a)" KR.Work.pp
+        kr (Fmt.option Quarter.pp) kr.quarter
   | Invalid_objective w -> (
       match w with
       | Objective_not_found x ->

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -22,7 +22,7 @@ type lint_error =
   | Parsing_error of int option * Parser.Warning.t
   | Invalid_total_time of string * Time.t * Time.t
   | Invalid_quarter of KR.Work.t
-  | Invalid_objective of KR.warning
+  | Invalid_objective of KR.Warning.t
 
 type lint_result = (unit, lint_error list) result
 
@@ -63,20 +63,7 @@ let pp_error ppf = function
         "@[<hv 2>In objective \"%a\":@ Work logged on objective scheduled for \
          %a@]@,"
         KR.Work.pp kr (Fmt.option Quarter.pp) kr.quarter
-  | Invalid_objective w -> (
-      match w with
-      | Objective_not_found x ->
-          Fmt.pf ppf "@[<hv 2>Invalid objective:@ %S@]@," x.title
-      | Migration { work_item; objective = None } ->
-          Fmt.pf ppf
-            "@[<hv 2>Invalid objective:@ \"%a\" is a work-item, you should use \
-             an objective instead@]@,"
-            KR.Work.pp work_item
-      | Migration { work_item; objective = Some obj } ->
-          Fmt.pf ppf
-            "@[<hv 2>Invalid objective:@ \"%a\" is a work-item, you should use \
-             its parent objective \"%a\" instead@]@,"
-            KR.Work.pp work_item KR.Work.pp obj)
+  | Invalid_objective w -> Fmt.pf ppf "@[<hv 2>%a@]@," KR.Warning.pp w
 
 let string_of_error = Fmt.to_to_string pp_error
 
@@ -253,17 +240,4 @@ let short_messages_of_error file_name =
   | Invalid_quarter kr ->
       short_messagef None "Using KR of invalid quarter: \"%a\" (%a)" KR.Work.pp
         kr (Fmt.option Quarter.pp) kr.quarter
-  | Invalid_objective w -> (
-      match w with
-      | Objective_not_found x ->
-          short_messagef None "Invalid objective: %S" x.title
-      | Migration { work_item; objective = None } ->
-          short_messagef None
-            "Invalid objective:@ \"%a\" is a work-item, an objective should be \
-             used instead"
-            KR.Work.pp work_item
-      | Migration { work_item; objective = Some obj } ->
-          short_messagef None
-            "Invalid objective:@ \"%a\" is a work-item, its parent objective \
-             \"%a\" should be used instead"
-            KR.Work.pp work_item KR.Work.pp obj)
+  | Invalid_objective w -> short_messagef None "%a" KR.Warning.pp_short w

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -81,25 +81,13 @@ let grep_n s lines =
     (fun (i, line) -> if Str.string_match re line 0 then Some i else None)
     lines
 
-let lines_of_kr s lines = grep_n (Fmt.str "%a" KR.Heading.pp s) lines
-
-let add_context lines = function
-  | Parser.Warning.No_time_found s ->
-      Parsing_error (lines_of_kr s lines, No_time_found s)
-  | Parser.Warning.Invalid_time { kr; entry } ->
-      Parsing_error (grep_n entry lines, Invalid_time { kr; entry })
-  | Parser.Warning.Multiple_time_entries s ->
-      Parsing_error (lines_of_kr s lines, Multiple_time_entries s)
-  | Parser.Warning.No_work_found s ->
-      Parsing_error (lines_of_kr s lines, No_work_found s)
-  | Parser.Warning.No_KR_ID_found s ->
-      Parsing_error (grep_n s lines, No_KR_ID_found s)
-  | Parser.Warning.No_project_found s ->
-      Parsing_error (lines_of_kr s lines, No_project_found s)
-  | Parser.Warning.Not_all_includes_accounted_for s ->
-      Parsing_error (None, Not_all_includes_accounted_for s)
-  | Parser.Warning.Invalid_markdown_in_work_items s ->
-      Parsing_error (grep_n s lines, Invalid_markdown_in_work_items s)
+let add_context lines w =
+  let line_number =
+    match Parser.Warning.greppable w with
+    | Some s -> grep_n s lines
+    | None -> None
+  in
+  Parsing_error (line_number, w)
 
 let check_total_time ?check_time (krs : KR.t list) report_kind =
   match report_kind with

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -19,7 +19,7 @@ let ( let* ) = Result.bind
 
 type lint_error =
   | Format_error of (int * string) list
-  | Parsing_error of int option * Parser.warning
+  | Parsing_error of int option * Parser.Warning.t
   | Invalid_total_time of string * Time.t * Time.t
   | Invalid_quarter of KR.Work.t
   | Invalid_objective of KR.warning
@@ -53,47 +53,11 @@ let pp_error ppf = function
       Fmt.pf ppf "@[<v 0>%a@,%d formatting errors found. Parsing aborted.@]"
         (Fmt.list ~sep:Fmt.sp pp_msg)
         x (List.length x)
-  | Parsing_error (_, No_time_found kr) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective \"%a\":@ No time entry found. Each objective \
-         must be followed by '- @@... (x days)'@]@,"
-        KR.Heading.pp kr
-  | Parsing_error (_, Invalid_time { kr; entry }) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective \"%a\":@ Invalid time entry %S found. Format is \
-         '- @@eng1 (x days), @@eng2 (y days)'@ where x and y must be divisible \
-         by 0.5@]@,"
-        KR.Heading.pp kr entry
+  | Parsing_error (_, w) -> Fmt.pf ppf "@[<hv 2>%a@]@," Parser.Warning.pp w
   | Invalid_total_time (s, t, total) ->
       Fmt.pf ppf
         "@[<hv 2>Invalid total time found for %s (reported %a, expected %a).@]@,"
         s Time.pp t Time.pp total
-  | Parsing_error (_, Multiple_time_entries kr) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective \"%a\":@ Multiple time entries found. Only one \
-         time entry should follow immediately after the objective.@]@,"
-        KR.Heading.pp kr
-  | Parsing_error (_, No_work_found kr) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective \"%a\":@ No work items found. This may indicate \
-         an unreported parsing error. Remove the objective if it is without \
-         work.@]@,"
-        KR.Heading.pp kr
-  | Parsing_error (_, No_KR_ID_found s) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective %S:@ No ID found. Objectives should be in the \
-         format \"This is an objective (#123)\", where 123 is the objective \
-         issue ID. For objectives that don't have an ID yet, use \"New KR\" \
-         and for work without an objective use \"No KR\".@]@,"
-        s
-  | Parsing_error (_, No_project_found kr) ->
-      Fmt.pf ppf
-        "@[<hv 2>In objective \"%a\":@ No project found (starting with '#')@]@,"
-        KR.Heading.pp kr
-  | Parsing_error (_, Not_all_includes_accounted_for s) ->
-      Fmt.pf ppf "Missing includes section: %a\n" Fmt.(list ~sep:comma string) s
-  | Parsing_error (_, Invalid_markdown_in_work_items s) ->
-      Fmt.pf ppf "@[<hv 2>Invalid markdown:@ %s@]@," s
   | Invalid_quarter kr ->
       Fmt.pf ppf
         "@[<hv 2>In objective \"%a\":@ Work logged on objective scheduled for \
@@ -133,20 +97,21 @@ let grep_n s lines =
 let lines_of_kr s lines = grep_n (Fmt.str "%a" KR.Heading.pp s) lines
 
 let add_context lines = function
-  | Parser.No_time_found s ->
+  | Parser.Warning.No_time_found s ->
       Parsing_error (lines_of_kr s lines, No_time_found s)
-  | Parser.Invalid_time { kr; entry } ->
+  | Parser.Warning.Invalid_time { kr; entry } ->
       Parsing_error (grep_n entry lines, Invalid_time { kr; entry })
-  | Parser.Multiple_time_entries s ->
+  | Parser.Warning.Multiple_time_entries s ->
       Parsing_error (lines_of_kr s lines, Multiple_time_entries s)
-  | Parser.No_work_found s ->
+  | Parser.Warning.No_work_found s ->
       Parsing_error (lines_of_kr s lines, No_work_found s)
-  | Parser.No_KR_ID_found s -> Parsing_error (grep_n s lines, No_KR_ID_found s)
-  | Parser.No_project_found s ->
+  | Parser.Warning.No_KR_ID_found s ->
+      Parsing_error (grep_n s lines, No_KR_ID_found s)
+  | Parser.Warning.No_project_found s ->
       Parsing_error (lines_of_kr s lines, No_project_found s)
-  | Parser.Not_all_includes_accounted_for s ->
+  | Parser.Warning.Not_all_includes_accounted_for s ->
       Parsing_error (None, Not_all_includes_accounted_for s)
-  | Parser.Invalid_markdown_in_work_items s ->
+  | Parser.Warning.Invalid_markdown_in_work_items s ->
       Parsing_error (grep_n s lines, Invalid_markdown_in_work_items s)
 
 let check_total_time ?check_time (krs : KR.t list) report_kind =
@@ -280,28 +245,11 @@ let short_messages_of_error file_name =
       List.concat_map
         (fun (line_number, message) -> short_message line_number message)
         errs
-  | Parsing_error (line_number, No_time_found kr) ->
-      short_messagef line_number "No time found in \"%a\"" KR.Heading.pp kr
-  | Parsing_error (line_number, Invalid_time { kr; entry }) ->
-      short_messagef line_number "Invalid time entry %S in \"%a\"" entry
-        KR.Heading.pp kr
+  | Parsing_error (line_number, w) ->
+      short_messagef line_number "%a" Parser.Warning.pp_short w
   | Invalid_total_time (s, t, total) ->
       short_messagef None "Invalid total time for %S (%a/%a)" s Time.pp t
         Time.pp total
-  | Parsing_error (line_number, Multiple_time_entries kr) ->
-      short_messagef line_number "Multiple time entries for \"%a\""
-        KR.Heading.pp kr
-  | Parsing_error (line_number, No_work_found kr) ->
-      short_messagef line_number "No work found for \"%a\"" KR.Heading.pp kr
-  | Parsing_error (line_number, No_KR_ID_found kr) ->
-      short_messagef line_number "No KR ID found for %S" kr
-  | Parsing_error (line_number, No_project_found kr) ->
-      short_messagef line_number "No project found for \"%a\"" KR.Heading.pp kr
-  | Parsing_error (line_number, Not_all_includes_accounted_for l) ->
-      short_messagef line_number "Missing includes section: %s"
-        (String.concat ", " l)
-  | Parsing_error (line_number, Invalid_markdown_in_work_items s) ->
-      short_messagef line_number "Invalid markdown in work items: %s" s
   | Invalid_quarter kr ->
       short_messagef None "Using KR of invalid quarter: \"%a\" (%a)" KR.Work.pp
         kr (Fmt.option Quarter.pp) kr.quarter

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -20,7 +20,7 @@ type lint_error =
   | Parsing_error of int option * Parser.Warning.t
   | Invalid_total_time of string * Time.t * Time.t
   | Invalid_quarter of KR.Work.t
-  | Invalid_objective of KR.warning
+  | Invalid_objective of KR.Warning.t
 
 type lint_result = (unit, lint_error list) result
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -17,7 +17,7 @@
 
 type lint_error =
   | Format_error of (int * string) list
-  | Parsing_error of int option * Parser.warning
+  | Parsing_error of int option * Parser.Warning.t
   | Invalid_total_time of string * Time.t * Time.t
   | Invalid_quarter of KR.Work.t
   | Invalid_objective of KR.warning

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -17,15 +17,8 @@
 
 type lint_error =
   | Format_error of (int * string) list
-  | No_time_found of int option * KR.Heading.t
-  | Invalid_time of { lnum : int option; kr : KR.Heading.t; entry : string }
+  | Parsing_error of int option * Parser.warning
   | Invalid_total_time of string * Time.t * Time.t
-  | Multiple_time_entries of int option * KR.Heading.t
-  | No_work_found of int option * KR.Heading.t
-  | No_KR_ID_found of int option * string
-  | No_project_found of int option * KR.Heading.t
-  | Not_all_includes of string list
-  | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t
   | Invalid_objective of KR.warning
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -17,13 +17,13 @@
 
 type lint_error =
   | Format_error of (int * string) list
-  | No_time_found of int option * string
-  | Invalid_time of { lnum : int option; title : string; entry : string }
+  | No_time_found of int option * KR.Heading.t
+  | Invalid_time of { lnum : int option; kr : KR.Heading.t; entry : string }
   | Invalid_total_time of string * Time.t * Time.t
-  | Multiple_time_entries of int option * string
-  | No_work_found of int option * string
+  | Multiple_time_entries of int option * KR.Heading.t
+  | No_work_found of int option * KR.Heading.t
   | No_KR_ID_found of int option * string
-  | No_project_found of int option * string
+  | No_project_found of int option * KR.Heading.t
   | Not_all_includes of string list
   | Invalid_markdown_in_work_items of int option * string
   | Invalid_quarter of KR.Work.t

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -83,6 +83,16 @@ module Warning = struct
         Fmt.pf ppf "Missing includes section: %s" (String.concat ", " l)
     | Invalid_markdown_in_work_items s ->
         Fmt.pf ppf "Invalid markdown in work items: %s" s
+
+  let greppable = function
+    | No_time_found s -> Some (Fmt.str "%a" KR.Heading.pp s)
+    | Invalid_time { kr = _; entry } -> Some entry
+    | Multiple_time_entries s -> Some (Fmt.str "%a" KR.Heading.pp s)
+    | No_work_found s -> Some (Fmt.str "%a" KR.Heading.pp s)
+    | No_KR_ID_found s -> Some s
+    | No_project_found s -> Some (Fmt.str "%a" KR.Heading.pp s)
+    | Not_all_includes_accounted_for _ -> None
+    | Invalid_markdown_in_work_items s -> Some s
 end
 
 (* Types for parsing the AST *)

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -16,18 +16,24 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type warning =
-  | No_time_found of KR.Heading.t  (** Record found without a time record *)
-  | Multiple_time_entries of KR.Heading.t  (** More than one time entry found *)
-  | Invalid_time of { kr : KR.Heading.t; entry : string }
-      (** Time record found, but has errors *)
-  | No_work_found of KR.Heading.t  (** No work items found under KR *)
-  | No_KR_ID_found of string  (** Empty or no KR ID *)
-  | No_project_found of KR.Heading.t  (** No project found *)
-  | Not_all_includes_accounted_for of string list
-      (** There should be a section for all include sections passed to the parser *)
-  | Invalid_markdown_in_work_items of string
-      (** Subset of markdown not supported in work items *)
+module Warning : sig
+  type t =
+    | No_time_found of KR.Heading.t  (** Record found without a time record *)
+    | Multiple_time_entries of KR.Heading.t
+        (** More than one time entry found *)
+    | Invalid_time of { kr : KR.Heading.t; entry : string }
+        (** Time record found, but has errors *)
+    | No_work_found of KR.Heading.t  (** No work items found under KR *)
+    | No_KR_ID_found of string  (** Empty or no KR ID *)
+    | No_project_found of KR.Heading.t  (** No project found *)
+    | Not_all_includes_accounted_for of string list
+        (** There should be a section for all include sections passed to the parser *)
+    | Invalid_markdown_in_work_items of string
+        (** Subset of markdown not supported in work items *)
+
+  val pp : t Fmt.t
+  val pp_short : t Fmt.t
+end
 
 type markdown = Omd.doc
 (** The type for markdown files. *)
@@ -41,7 +47,7 @@ val of_markdown :
   ?include_sections:string list ->
   report_kind ->
   markdown ->
-  KR.t list * warning list
+  KR.t list * Warning.t list
 (** Process markdown data from omd. Optionally [ignore_sections] can be used to
     ignore specific sections, or [include_sections] can be used to only process
     specific sections. *)

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -33,6 +33,7 @@ module Warning : sig
 
   val pp : t Fmt.t
   val pp_short : t Fmt.t
+  val greppable : t -> string option
 end
 
 type markdown = Omd.doc

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -17,13 +17,13 @@
  *)
 
 type warning =
-  | No_time_found of string  (** Record found without a time record *)
-  | Multiple_time_entries of string  (** More than one time entry found *)
-  | Invalid_time of { title : string; entry : string }
+  | No_time_found of KR.Heading.t  (** Record found without a time record *)
+  | Multiple_time_entries of KR.Heading.t  (** More than one time entry found *)
+  | Invalid_time of { kr : KR.Heading.t; entry : string }
       (** Time record found, but has errors *)
-  | No_work_found of string  (** No work items found under KR *)
+  | No_work_found of KR.Heading.t  (** No work items found under KR *)
   | No_KR_ID_found of string  (** Empty or no KR ID *)
-  | No_project_found of string  (** No project found *)
+  | No_project_found of KR.Heading.t  (** No project found *)
   | Not_all_includes_accounted_for of string list
       (** There should be a section for all include sections passed to the parser *)
   | Invalid_markdown_in_work_items of string

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -212,13 +212,16 @@ let of_krs ?okr_db entries =
   (t, warnings)
 
 let pp_warning ppf = function
-  | Parser.No_time_found s -> Fmt.pf ppf "No time found in %S" s
-  | Invalid_time { title; entry } ->
-      Fmt.pf ppf "Invalid time entry %S in %S" entry title
-  | Multiple_time_entries s -> Fmt.pf ppf "Multiple time entries for %S" s
-  | No_work_found s -> Fmt.pf ppf "No work found for %S" s
+  | Parser.No_time_found s ->
+      Fmt.pf ppf "No time found in \"%a\"" KR.Heading.pp s
+  | Invalid_time { kr; entry } ->
+      Fmt.pf ppf "Invalid time entry %S in \"%a\"" entry KR.Heading.pp kr
+  | Multiple_time_entries s ->
+      Fmt.pf ppf "Multiple time entries for \"%a\"" KR.Heading.pp s
+  | No_work_found s -> Fmt.pf ppf "No work found for \"%a\"" KR.Heading.pp s
   | No_KR_ID_found s -> Fmt.pf ppf "No KR ID found for %S" s
-  | No_project_found s -> Fmt.pf ppf "No project found for %S" s
+  | No_project_found s ->
+      Fmt.pf ppf "No project found for \"%a\"" KR.Heading.pp s
   | Not_all_includes_accounted_for s ->
       Fmt.pf ppf "Missing includes section: %a" Fmt.(list ~sep:comma string) s
   | Invalid_markdown_in_work_items s ->

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -211,22 +211,6 @@ let of_krs ?okr_db entries =
   let warnings = List.rev @@ List.filter_map (add ?okr_db t) entries in
   (t, warnings)
 
-let pp_warning ppf = function
-  | Parser.Warning.No_time_found s ->
-      Fmt.pf ppf "No time found in \"%a\"" KR.Heading.pp s
-  | Invalid_time { kr; entry } ->
-      Fmt.pf ppf "Invalid time entry %S in \"%a\"" entry KR.Heading.pp kr
-  | Multiple_time_entries s ->
-      Fmt.pf ppf "Multiple time entries for \"%a\"" KR.Heading.pp s
-  | No_work_found s -> Fmt.pf ppf "No work found for \"%a\"" KR.Heading.pp s
-  | No_KR_ID_found s -> Fmt.pf ppf "No KR ID found for %S" s
-  | No_project_found s ->
-      Fmt.pf ppf "No project found for \"%a\"" KR.Heading.pp s
-  | Not_all_includes_accounted_for s ->
-      Fmt.pf ppf "Missing includes section: %a" Fmt.(list ~sep:comma string) s
-  | Invalid_markdown_in_work_items s ->
-      Fmt.pf ppf "Invalid markdown in work items: %s" s
-
 let of_markdown ?existing_report ?ignore_sections ?include_sections ?okr_db
     ?report_kind m =
   let kind = Option.value report_kind ~default:Parser.default_report_kind in
@@ -234,7 +218,7 @@ let of_markdown ?existing_report ?ignore_sections ?include_sections ?okr_db
     Parser.of_markdown ?ignore_sections ?include_sections kind m
   in
   List.iter
-    (fun w -> Logs.warn (fun m -> m "@[<v 0>%a@]" pp_warning w))
+    (fun w -> Logs.warn (fun m -> m "@[<v 0>%a@]" Parser.Warning.pp_short w))
     warnings;
   let old_krs = match existing_report with None -> [] | Some t -> all_krs t in
   let krs = old_krs @ new_krs in

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -212,7 +212,7 @@ let of_krs ?okr_db entries =
   (t, warnings)
 
 let pp_warning ppf = function
-  | Parser.No_time_found s ->
+  | Parser.Warning.No_time_found s ->
       Fmt.pf ppf "No time found in \"%a\"" KR.Heading.pp s
   | Invalid_time { kr; entry } ->
       Fmt.pf ppf "Invalid time entry %S in \"%a\"" entry KR.Heading.pp kr

--- a/lib/report.mli
+++ b/lib/report.mli
@@ -34,7 +34,7 @@ module Objective : sig
 end
 
 val empty : unit -> t
-val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t * KR.warning list
+val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t * KR.Warning.t list
 
 val of_markdown :
   ?existing_report:t ->
@@ -43,7 +43,7 @@ val of_markdown :
   ?okr_db:Masterdb.t ->
   ?report_kind:Parser.report_kind ->
   Parser.markdown ->
-  t * KR.warning list
+  t * KR.Warning.t list
 
 val iter :
   ?project:(string -> project -> unit) ->
@@ -53,7 +53,7 @@ val iter :
   unit
 
 val find : t -> KR.Id.t -> KR.t list
-val add : ?okr_db:Masterdb.t -> t -> KR.t -> KR.warning option
+val add : ?okr_db:Masterdb.t -> t -> KR.t -> KR.Warning.t option
 val all_krs : t -> KR.t list
 
 val pp :

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -62,12 +62,12 @@ Errors in include section are detected even if the rest is ignored.
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "This is a KR":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
+  In objective "This is a KR":
+    No ID found. Objectives should be in the format "This is an objective (#123)", where 123 is the objective issue ID. For objectives that don't have an ID yet, use "New KR" and for work without an objective use "No KR".
   [1]
 
 Only "No KR" and "New KR" are supported for KR's without identifiers
@@ -95,8 +95,8 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   Invalid total time found for eng1 (reported 1 day, expected 5 days).
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
+  In objective "This is a KR":
+    No ID found. Objectives should be in the format "This is an objective (#123)", where 123 is the objective issue ID. For objectives that don't have an ID yet, use "New KR" and for work without an objective use "No KR".
   [1]
 
   $ okra lint --engineer << EOF
@@ -119,7 +119,7 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR1)":
+  In objective "This is a KR (KR1)":
     Invalid time entry "@eng1 (1.1 day)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]
@@ -144,7 +144,7 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR1)":
+  In objective "This is a KR (KR1)":
     Invalid time entry "@eng1 ( day)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -237,8 +237,7 @@ Format errors
   $ okra lint --include-sections "Section A,Section B" err-not-all-includes.md
   [ERROR(S)]: err-not-all-includes.md
   
-  Missing includes section: SECTION B,
-  SECTION A
+  Missing includes section: SECTION B, SECTION A
   [1]
   $ okra lint --include-sections "Section A,Section B" --short err-not-all-includes.md
   err-not-all-includes.md:1:Missing includes section: SECTION B, SECTION A

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -12,8 +12,8 @@ No KR ID found:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
+  In objective "This is a KR":
+    No ID found. Objectives should be in the format "This is an objective (#123)", where 123 is the objective issue ID. For objectives that don't have an ID yet, use "New KR" and for work without an objective use "No KR".
   [1]
 
   $ okra lint << EOF
@@ -23,7 +23,7 @@ No KR ID found:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR123)": No project found (starting with '#')
+  In objective "This is a KR (KR123)": No project found (starting with '#')
   [1]
 
 No work items found:
@@ -36,12 +36,12 @@ No work items found:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
+  In objective "This is a KR":
+    No work items found. This may indicate an unreported parsing error. Remove the objective if it is without work.
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
+  In objective "This is a KR":
+    No ID found. Objectives should be in the format "This is an objective (#123)", where 123 is the objective issue ID. For objectives that don't have an ID yet, use "New KR" and for work without an objective use "No KR".
   [1]
 
 No time entry found:
@@ -55,8 +55,8 @@ No time entry found:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR12)":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "This is a KR (KR12)":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [1]
 
 Multiple time entries:
@@ -72,8 +72,8 @@ Multiple time entries:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR12)":
-    Multiple time entries found. Only one time entry should follow immediately after the KR.
+  In objective "This is a KR (KR12)":
+    Multiple time entries found. Only one time entry should follow immediately after the objective.
   [1]
 
 Format errors
@@ -137,8 +137,8 @@ Format errors
   $ okra lint err-no-time.md
   [ERROR(S)]: err-no-time.md
   
-  In KR "Everything is great (E1)":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "Everything is great (E1)":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [1]
   $ okra lint --short err-no-time.md
   err-no-time.md:3:No time found in "Everything is great (E1)"
@@ -154,7 +154,7 @@ Format errors
   $ okra lint err-invalid-time.md
   [ERROR(S)]: err-invalid-time.md
   
-  In KR "Everything is great (E1)":
+  In objective "Everything is great (E1)":
     Invalid time entry "@a (day)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]
@@ -173,8 +173,8 @@ Format errors
   $ okra lint err-multiple-time.md
   [ERROR(S)]: err-multiple-time.md
   
-  In KR "Everything is great (E1)":
-    Multiple time entries found. Only one time entry should follow immediately after the KR.
+  In objective "Everything is great (E1)":
+    Multiple time entries found. Only one time entry should follow immediately after the objective.
   [1]
   $ okra lint --short err-multiple-time.md
   err-multiple-time.md:3:Multiple time entries for "Everything is great (E1)"
@@ -189,8 +189,8 @@ Format errors
   $ okra lint err-no-work.md
   [ERROR(S)]: err-no-work.md
   
-  In KR "Everything is great (E1)":
-    No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
+  In objective "Everything is great (E1)":
+    No work items found. This may indicate an unreported parsing error. Remove the objective if it is without work.
   [1]
   $ okra lint --short err-no-work.md
   err-no-work.md:3:No work found for "Everything is great (E1)"
@@ -206,8 +206,8 @@ Format errors
   $ okra lint err-no-kr-id.md
   [ERROR(S)]: err-no-kr-id.md
   
-  In KR "Everything is great":
-    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For WIs that don't have an ID yet, use "New WI" and for work without a WI use "No WI".
+  In objective "Everything is great":
+    No ID found. Objectives should be in the format "This is an objective (#123)", where 123 is the objective issue ID. For objectives that don't have an ID yet, use "New KR" and for work without an objective use "No KR".
   [1]
   $ okra lint --short err-no-kr-id.md
   err-no-kr-id.md:3:No KR ID found for "Everything is great"
@@ -221,7 +221,7 @@ Format errors
   $ okra lint err-no-project.md
   [ERROR(S)]: err-no-project.md
   
-  In KR "Everything is great (E1)": No project found (starting with '#')
+  In objective "Everything is great (E1)": No project found (starting with '#')
   [1]
   $ okra lint --short err-no-project.md
   err-no-project.md:1:No project found for "Everything is great (E1)"

--- a/test/cram/lint/features.t
+++ b/test/cram/lint/features.t
@@ -9,8 +9,8 @@ Lint can read from a file:
   $ okra lint err.md
   [ERROR(S)]: err.md
   
-  In KR "Everything is great (E1)":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "Everything is great (E1)":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [1]
 
 It can also read from stdin:
@@ -18,8 +18,8 @@ It can also read from stdin:
   $ okra lint < err.md
   [ERROR(S)]: <stdin>
   
-  In KR "Everything is great (E1)":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "Everything is great (E1)":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [1]
 
 If everything is fine, nothing is printed and it exits with 0:
@@ -49,13 +49,13 @@ When errors are found in several files, they are all printed:
   $ okra lint err.md err2.md
   [ERROR(S)]: err2.md
   
-  In KR "Everything is great (E1)":
+  In objective "Everything is great (E1)":
     Invalid time entry "@a" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [ERROR(S)]: err.md
   
-  In KR "Everything is great (E1)":
-    No time entry found. Each KR must be followed by '- @... (x days)'
+  In objective "Everything is great (E1)":
+    No time entry found. Each objective must be followed by '- @... (x days)'
   [1]
 
 A warning is emitted when the generated report contains placeholder text:

--- a/test/cram/lint/includes.t
+++ b/test/cram/lint/includes.t
@@ -48,6 +48,5 @@ The include_section checker looks for all passed sections
   > EOF
   [ERROR(S)]: <stdin>
   
-  Missing includes section: NEXT WEEK,
-  LAST WEEK
+  Missing includes section: NEXT WEEK, LAST WEEK
   [1]

--- a/test/cram/lint/time.t
+++ b/test/cram/lint/time.t
@@ -12,7 +12,7 @@ Invalid time
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR123)":
+  In objective "This is a KR (KR123)":
     Invalid time entry "@eng1 (1 day), eng2 (2 days)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]
@@ -25,7 +25,7 @@ Invalid time
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR123)":
+  In objective "This is a KR (KR123)":
     Invalid time entry "@eng1 (1 day); @eng2 (2 days)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]
@@ -38,7 +38,7 @@ Invalid time
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR123)":
+  In objective "This is a KR (KR123)":
     Invalid time entry "@eng1 (1 day) @eng2 (2 days)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]
@@ -51,7 +51,7 @@ Invalid time
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR (KR123)":
+  In objective "This is a KR (KR123)":
     Invalid time entry "@eng1 (. days)" found. Format is '- @eng1 (x days), @eng2 (y days)'
     where x and y must be divisible by 0.5
   [1]


### PR DESCRIPTION
Closes #238, the IDs were already properly printed. We now make it more obvious in the types of the error messages.

"KR" has been replaced by "Objective" in error messages as well.

Plus a bit of refactoring to make it easier to maintain.