### PR TITLE
Fix missing trailing break after format error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fix: Use the admin_dir field in conf file to infer the path to WI/obj DB (#253, @gpetiot)
+- Fix missing trailing break after format error messages (#250, @gpetiot)
 
 ## 2.0.1
 

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -44,8 +44,10 @@ module Error = struct
     in
     function
     | `Format_error x ->
-        let pp_msg ppf (pos, msg) = pf (Some pos) (fun m -> m ppf "%s" msg) in
-        Fmt.pf ppf "@[<v 0>%a@]" (Fmt.list ~sep:Fmt.nop pp_msg) x
+        let pp_msg ppf (pos, msg) =
+          pf (Some pos) (fun m -> m ppf "@[%s@]" msg)
+        in
+        Fmt.pf ppf "@[<v 0>%a@]" (Fmt.list ~sep:Fmt.sp pp_msg) x
     | `Parsing_error (line_number, w) ->
         pf line_number (fun m -> m ppf "@[<hv 0>%a@]" Parser.Warning.pp w)
     | `Invalid_total_time (s, t, total) ->

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -44,10 +44,8 @@ module Error = struct
     in
     function
     | `Format_error x ->
-        let pp_msg ppf (pos, msg) =
-          Fmt.pf ppf "File %S, line %d:@\nError: %s" filename pos msg
-        in
-        Fmt.pf ppf "@[<v 0>%a@]" (Fmt.list ~sep:Fmt.sp pp_msg) x
+        let pp_msg ppf (pos, msg) = pf (Some pos) (fun m -> m ppf "%s" msg) in
+        Fmt.pf ppf "@[<v 0>%a@]" (Fmt.list ~sep:Fmt.nop pp_msg) x
     | `Parsing_error (line_number, w) ->
         pf line_number (fun m -> m ppf "@[<hv 0>%a@]" Parser.Warning.pp w)
     | `Invalid_total_time (s, t, total) ->

--- a/lib/team.ml
+++ b/lib/team.ml
@@ -78,7 +78,7 @@ let pp_report ppf = function
   | { filename; status = Not_found; _ } -> Fmt.pf ppf "Not found: %s" filename
   | { filename; status = Not_lint e; _ } ->
       Fmt.pf ppf "Lint error at %s@ @[<v 0>%a@]" filename
-        (Fmt.list (Lint.Error.pp ~filename) ~sep:Fmt.nop)
+        (Fmt.list (Lint.Error.pp ~filename))
         e
 
 let result_partition f =

--- a/lib/team.ml
+++ b/lib/team.ml
@@ -78,7 +78,7 @@ let pp_report ppf = function
   | { filename; status = Not_found; _ } -> Fmt.pf ppf "Not found: %s" filename
   | { filename; status = Not_lint e; _ } ->
       Fmt.pf ppf "Lint error at %s@ @[<v 0>%a@]" filename
-        (Fmt.list (Lint.Error.pp ~filename))
+        (Fmt.list (Lint.Error.pp ~filename) ~sep:Fmt.nop)
         e
 
 let result_partition f =
@@ -102,7 +102,7 @@ let pp_member_lint ppf { member = _; week_reports } =
   else
     Error
       (fun () ->
-        Fmt.pf ppf "@[%a@]"
+        Fmt.pf ppf "@[<v 0>%a@]"
           (Fmt.list ~sep:(Fmt.any "@;<1 0>") pp_report_lint)
           not_complete)
 

--- a/test/cram/team-lint.t/run.t
+++ b/test/cram/team-lint.t/run.t
@@ -8,6 +8,7 @@ Team Lint example with invalid reports:
     + Report week 41: Lint error at admin//weekly/2022/41/eng2.md
                       File "admin//weekly/2022/41/eng2.md", line 4:
                       Error: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
+                      
                       File "admin//weekly/2022/41/eng2.md", line 5:
                       Error: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                       

--- a/test/cram/team-lint.t/run.t
+++ b/test/cram/team-lint.t/run.t
@@ -10,6 +10,7 @@ Team Lint example with invalid reports:
                       Error: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                       File "admin//weekly/2022/41/eng2.md", line 5:
                       Error: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
+                      
     + Report week 42: Not found: admin//weekly/2022/42/eng2.md
   [1]
 


### PR DESCRIPTION
Fix #249

This solution is not perfect (see the added linebreak in test/cram/team-lint.t/run.t) but it's the one with the least amount of regressions.
I checked every break and every box and I have no idea what is causing either the issue of #249 or the regression. But it's not too dirty so I'm fine with merging if the new output suits you @emillon 