### PR TITLE
Check the current version is compatible with the last release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- Check the current version is compatible with the last release (#<PR_NUMBER>, @gpetiot)
 - Update the Meta standardized categories: Off, Hack and Misc (#254, @gpetiot)
 
 ### Fixed

--- a/bin/dune
+++ b/bin/dune
@@ -12,6 +12,7 @@
   logs.cli
   fmt.tty
   dune-build-info
+  semver
   xdg)
  (preprocess
   (pps ppx_deriving_yaml)))

--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -87,25 +87,6 @@ let user : Get_activity.User.t Term.t =
   let doc = Arg.info ~doc:"User name" [ "user" ] in
   Arg.(value & opt user_conv Viewer & doc)
 
-(* Get activity configuration *)
-let home =
-  match Sys.getenv_opt "HOME" with
-  | None -> Fmt.failwith "$HOME is not set!"
-  | Some dir -> dir
-
-let default_token_file =
-  let ( / ) = Filename.concat in
-  home / ".github" / "github-activity-token"
-
-let token =
-  Arg.value
-  @@ Arg.opt Arg.file default_token_file
-  @@ Arg.info
-       ~doc:
-         "The path to a file containing your github token, defaults to \
-          ~/.github/github-activity-token"
-       ~docv:"TOKEN" [ "token" ]
-
 module User_fetch = Get_activity.Contributions
 module Repo_fetch = Okra.Repo_report
 
@@ -222,7 +203,7 @@ let run ppf cal conf token no_activity no_links with_names with_times
 let term =
   let open Let_syntax_cmdliner in
   let+ c = Common.term
-  and+ token_file = token
+  and+ token_file = Token.term
   and+ no_activity = no_activity
   and+ print_projects = print_projects
   and+ with_repositories = with_repositories_term

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -110,11 +110,20 @@ let format_term =
   in
   if short then Short else Pretty
 
+let get_or_error = function
+  | Ok v -> v
+  | Error (`Msg m) ->
+      Fmt.epr "%s" m;
+      exit 1
+
 let term =
   let open Let_syntax_cmdliner in
   let+ c = Common.term
   and+ format = format_term
+  and+ token_file = Token.term
   and+ input_files = Common.input_files in
+  let token = get_or_error @@ Get_activity.Token.load token_file in
+  Version.check ~token;
   run { c; input_files; format }
 
 let cmd =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -21,12 +21,8 @@ open Cmdliner
 let root_term = Term.ret (Term.const (`Help (`Pager, None)))
 
 let root_info =
-  let version =
-    match Build_info.V1.version () with
-    | None -> "dev"
-    | Some v -> Build_info.V1.Version.to_string v
-  in
-  Cmd.info "okra" ~version ~doc:"a tool to parse and process OKR reports"
+  Cmd.info "okra" ~version:Version.current
+    ~doc:"a tool to parse and process OKR reports"
     ~man:
       [
         `S Manpage.s_description;

--- a/bin/token.ml
+++ b/bin/token.ml
@@ -1,0 +1,18 @@
+let home =
+  match Sys.getenv_opt "HOME" with
+  | None -> Fmt.failwith "$HOME is not set!"
+  | Some dir -> dir
+
+let default_token_file =
+  let ( / ) = Filename.concat in
+  home / ".github" / "github-activity-token"
+
+let term =
+  let open Cmdliner in
+  Arg.value
+  @@ Arg.opt Arg.file default_token_file
+  @@ Arg.info
+       ~doc:
+         "The path to a file containing your github token, defaults to \
+          ~/.github/github-activity-token"
+       ~docv:"TOKEN" [ "token" ]

--- a/bin/token.mli
+++ b/bin/token.mli
@@ -1,0 +1,1 @@
+val term : string Cmdliner.Term.t

--- a/bin/version.ml
+++ b/bin/version.ml
@@ -1,0 +1,72 @@
+module U = Yojson.Safe.Util
+
+let ( / ) a b = U.member b a
+let ( let* ) = Result.bind
+
+let current =
+  match Build_info.V1.version () with
+  | None -> "dev"
+  | Some v -> Build_info.V1.Version.to_string v
+
+let query =
+  {|
+{
+  organization(login: "tarides") {
+    repository(name: "okra") {
+      latestRelease {
+        name
+      }
+    }
+  }
+}
+|}
+
+let pp = Fmt.of_to_string Semver.to_string
+
+let check ~token =
+  if current = "dev" then ()
+  else
+    match
+      let req = Get_activity.Graphql.request ~token ~query () in
+      let* resp = Get_activity.Graphql.exec req in
+      let json =
+        resp / "data" / "organization" / "repository" / "latestRelease" / "name"
+      in
+      let* last_version =
+        Option.to_result
+          ~none:
+            (`Msg
+              (Fmt.str "Invalid latest release %a. Please report this bug."
+                 Yojson.Safe.pp json))
+        @@ Yojson.Safe.Util.to_string_option json
+      in
+      let* last_version =
+        Option.to_result
+          ~none:
+            (`Msg
+              (Fmt.str "Invalid latest release %s. Please report this bug."
+                 last_version))
+        @@ Semver.of_string last_version
+      in
+      let* current_version =
+        Option.to_result
+          ~none:
+            (`Msg
+              (Fmt.str "Invalid current version %s. Please report this bug."
+                 current))
+        @@ Semver.of_string current
+      in
+      let l_major, l_minor, l_patch = last_version in
+      let c_major, c_minor, c_patch = current_version in
+      if l_major = c_major && l_minor = c_minor && l_patch >= c_patch then Ok ()
+      else
+        let msg =
+          Fmt.str "Invalid okra version. Expecting %a but you are using %a." pp
+            last_version pp current_version
+        in
+        Error (`Msg msg)
+    with
+    | Ok x -> x
+    | Error (`Msg e) ->
+        Fmt.epr "Error: %s\n" e;
+        exit 1

--- a/bin/version.mli
+++ b/bin/version.mli
@@ -1,0 +1,2 @@
+val current : string
+val check : token:string -> unit

--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
   bos
   dune-build-info
   (yaml (>= 3.0))
+  semver
   (cohttp-lwt-unix (>= 5.0.0))))
 
 (package

--- a/okra.opam
+++ b/okra.opam
@@ -20,6 +20,7 @@ depends: [
   "bos"
   "dune-build-info"
   "yaml" {>= "3.0"}
+  "semver"
   "cohttp-lwt-unix" {>= "5.0.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fix #171

This checks the version of the installed binary against the last release on github. I find it simpler than setting up a recommended/required version for the weeklies in the admin repo. But let me know what you think.